### PR TITLE
Fix Bouncy Castle security alerts

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 
 tomlj = "1.1.1"
+bouncycastle = "1.84"
 
 axion-release-plugin = "1.21.2"
 
@@ -16,6 +17,11 @@ gradle-plugin-publish = "2.1.1"
 [libraries]
 
 tomlj = { group = "org.tomlj", name = "tomlj", version.ref = "tomlj" }
+
+bouncycastle-bcpg = { module = "org.bouncycastle:bcpg-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-bcutil = { module = "org.bouncycastle:bcutil-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-bcpkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
 
 jacoco = { group = "org.jacoco", name = "org.jacoco.core", version.ref = "jacoco" }
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -5,6 +5,17 @@ import pl.allegro.tech.build.axion.release.domain.preRelease
 group = "com.the13haven"
 project.version = scmVersion.version
 
+buildscript {
+    dependencies {
+        constraints {
+            classpath(libs.bouncycastle.bcpg)
+            classpath(libs.bouncycastle.bcprov)
+            classpath(libs.bouncycastle.bcutil)
+            classpath(libs.bouncycastle.bcpkix)
+        }
+    }
+}
+
 plugins {
     `kotlin-dsl`
     alias(libs.plugins.gradle.plugin.publish)

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTask.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTask.kt
@@ -23,10 +23,13 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import java.util.Locale
 
@@ -35,6 +38,9 @@ import java.util.Locale
  *
  * @author ssidorov@the13haven.com
  */
+@DisableCachingByDefault(
+    because = "The task does not remove stale generated sources when an input catalog is removed"
+)
 abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
 
     @get:Input
@@ -42,6 +48,7 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
 
     @get:SkipWhenEmpty
     @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val tomlFiles: ConfigurableFileCollection
 
     @get:OutputDirectory


### PR DESCRIPTION
## Summary
- centralize Bouncy Castle 1.84 in the Gradle version catalog
- constrain the Axion/JGit build classpath to patched Bouncy Castle modules
- fix Gradle plugin validation with cacheability and relative path-sensitivity annotations

## Validation
- `./gradlew :plugin:validatePlugins --no-daemon --console=plain`
- `./gradlew :plugin:test --no-daemon --console=plain`
- `./gradlew build --no-daemon --console=plain`