### PR TITLE
Fix configuration cache compatibility

### DIFF
--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTask.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTask.kt
@@ -46,6 +46,9 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
     @get:Input
     abstract val catalogPackage: Property<String>
 
+    @get:Input
+    abstract val projectVersion: Property<String>
+
     @get:SkipWhenEmpty
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -70,8 +73,7 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
         }
 
         val filteredTomlFiles = tomlFiles.files
-            .map { filePath ->
-                val tomlFile = project.file(filePath)
+            .map { tomlFile ->
                 if (!tomlFile.exists()) {
                     throw IllegalStateException("Version catalog file not found: ${tomlFile.absolutePath}")
                 }
@@ -88,7 +90,7 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
                 tomlFile,
                 catalogPackage.get(),
                 className,
-                project.version.toString()
+                projectVersion.get()
             )
 
             if (classContent.isNotBlank()) {
@@ -99,11 +101,15 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
     }
 
     companion object {
-        fun Project.generatePortableVersionCatalogTask(extension: PortableVersionCatalogGeneratorPluginExtension): TaskProvider<PortableVersionCatalogGeneratorPluginTask> =
-            tasks.register<PortableVersionCatalogGeneratorPluginTask>("generatePortableVersionCatalog") {
+        fun Project.generatePortableVersionCatalogTask(extension: PortableVersionCatalogGeneratorPluginExtension): TaskProvider<PortableVersionCatalogGeneratorPluginTask> {
+            val projectVersionProvider = provider { version.toString() }
+
+            return tasks.register<PortableVersionCatalogGeneratorPluginTask>("generatePortableVersionCatalog") {
                 catalogPackage.set(extension.catalogPackage)
+                projectVersion.set(projectVersionProvider)
                 tomlFiles.setFrom(extension.tomlFiles)
                 outputDir.set(extension.outputDir)
             }
+        }
     }
 }

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTaskTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTaskTest.kt
@@ -51,6 +51,7 @@ class PortableVersionCatalogGeneratorPluginTaskTest {
         task = project.tasks.register("generateCatalog", PortableVersionCatalogGeneratorPluginTask::class.java)
 
         task.get().catalogPackage.set("com.example.catalog")
+        task.get().projectVersion.set("1.0.0")
         task.get().outputDir.set(tempDir)
     }
 

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
@@ -16,6 +16,8 @@
 package com.the13haven.gradle.povercat
 
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -34,7 +36,7 @@ class PortableVersionCatalogGeneratorPluginTest {
     val versionsFileName = "versions.toml"
 
     @Test
-    fun `apply plugin and verify task exists`() {
+    fun `generate catalog with reusable configuration cache`() {
         // 1. Create test build.gradle.kts
         writeBuildFile()
 
@@ -48,21 +50,34 @@ class PortableVersionCatalogGeneratorPluginTest {
         srcMainJava.mkdirs()
 
         // 3. Run Gradle task
-        val result = GradleRunner.create()
+        val runner = GradleRunner.create()
             .withProjectDir(projectDir)
             .withPluginClasspath()
-            .withArguments("generatePortableVersionCatalog", "--info")
-            .withDebug(true)
+            .withArguments(
+                "generatePortableVersionCatalog",
+                "--configuration-cache",
+                "--configuration-cache-problems=fail"
+            )
             .forwardOutput()
-            .build()
+
+        val firstRun = runner.build()
 
         // 4. Verify
-        assertTrue(result.output.contains("BUILD SUCCESSFUL"))
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            firstRun.task(":generatePortableVersionCatalog")?.outcome
+        )
+        assertTrue(firstRun.output.contains("Configuration cache entry stored."))
+
+        val secondRun = runner.build()
+        assertTrue(secondRun.output.contains("Configuration cache entry reused."))
 
         // 5. Check files
         val generatedDir = projectDir.resolve("build/generated/sources")
         assertTrue(generatedDir.exists())
-        assertTrue(generatedDir.resolve("com/example/catalog/VersionsCatalog.kt").exists())
+        val generatedCatalog = generatedDir.resolve("com/example/catalog/VersionsCatalog.kt")
+        assertTrue(generatedCatalog.exists())
+        assertTrue(generatedCatalog.readText().contains("@version v1.2.3"))
     }
 
     private fun writeBuildFile() {
@@ -80,6 +95,8 @@ class PortableVersionCatalogGeneratorPluginTest {
                 tomlFiles.setFrom("${projectDir.absolutePath}/${versionsFileName}")
                 outputDir.set(file("build/generated/sources"))
             }
+
+            version = "1.2.3"
             """.trimIndent()
         )
     }

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
@@ -70,6 +70,10 @@ class PortableVersionCatalogGeneratorPluginTest {
         assertTrue(firstRun.output.contains("Configuration cache entry stored."))
 
         val secondRun = runner.build()
+        assertEquals(
+            TaskOutcome.UP_TO_DATE,
+            secondRun.task(":generatePortableVersionCatalog")?.outcome
+        )
         assertTrue(secondRun.output.contains("Configuration cache entry reused."))
 
         // 5. Check files
@@ -78,9 +82,19 @@ class PortableVersionCatalogGeneratorPluginTest {
         val generatedCatalog = generatedDir.resolve("com/example/catalog/VersionsCatalog.kt")
         assertTrue(generatedCatalog.exists())
         assertTrue(generatedCatalog.readText().contains("@version v1.2.3"))
+
+        // 6. Change a declared task input and verify the catalog is regenerated
+        writeBuildFile(projectVersion = "2.0.0")
+
+        val thirdRun = runner.build()
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            thirdRun.task(":generatePortableVersionCatalog")?.outcome
+        )
+        assertTrue(generatedCatalog.readText().contains("@version v2.0.0"))
     }
 
-    private fun writeBuildFile() {
+    private fun writeBuildFile(projectVersion: String = "1.2.3") {
         val buildFile = projectDir.resolve("build.gradle.kts")
         buildFile.writeText(
             """
@@ -96,7 +110,7 @@ class PortableVersionCatalogGeneratorPluginTest {
                 outputDir.set(file("build/generated/sources"))
             }
 
-            version = "1.2.3"
+            version = "$projectVersion"
             """.trimIndent()
         )
     }


### PR DESCRIPTION
## Summary
- model the project version as an explicit task input
- remove `Project` access from `PortableVersionCatalogGeneratorPluginTask` execution
- add a TestKit regression test that stores and reuses the configuration cache
- verify the configured project version is preserved in generated output

## Verification
- `./gradlew clean check --rerun-tasks --console=plain`
- configuration cache entry reused successfully