### PR TITLE
Make Kotlin DSL integration order independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,33 @@
 
 <span style="color:orange;font-weight:900;">POVERCAT</span> is an abbreviation of the words <span style="color:orange;font-weight:900;">PO</span>rtable <span style="color:orange;font-weight:900;">VER</span>sion <span style="color:orange;font-weight:900;">CAT</span>alog
 
-Povercat is a Gradle plugin that generates a kotlin class from a TOML based version catalog and distribute it as a dependency.
+PoVerCat is a Gradle plugin that generates Kotlin classes from TOML-based version
+catalogs in a catalog producer project. The producer publishes the compiled classes
+as a regular dependency, which can then be used from both Kotlin and Java projects.
+
+The catalog producer must apply the Gradle `kotlin-dsl` plugin or the Kotlin JVM
+plugin because PoVerCat generates Kotlin source code. Consumer projects do not need
+to use Kotlin: they consume the already compiled artifact.
 
 ## Features
 
 * Automatic class generation from multiple TOML files
 * Portable and reusable version catalog class
-* Compatible with Java and Kotlin
+* Generated catalog artifacts are usable from both Kotlin and Java
 * Seamless integration with Gradle projects
 * Minimal settings for default case
+
+## Compatibility model
+
+PoVerCat distinguishes between the project that generates the catalog and the
+projects that consume it:
+
+* **Catalog producer** — a Gradle project that applies `kotlin-dsl` or
+  `org.jetbrains.kotlin.jvm`. PoVerCat generates Kotlin source code, adds it to the
+  main source set, and runs generation before `compileKotlin`.
+* **Catalog consumer** — a Kotlin or Java project that declares a dependency on the
+  artifact published by the producer. Consumers use compiled classes and therefore
+  do not need to apply PoVerCat or the Kotlin plugin.
 
 ## Plugin usage
 
@@ -49,13 +67,17 @@ Then, apply the plugin in your `build.gradle.kts` file:
 
 ```kotlin
 plugins {
-    id("com.l13.plugin.povercat") version "0.1.0"
+    `kotlin-dsl`
+    id("com.the13haven.povercat") version "0.1.0"
 }
 ```
 
+The Kotlin plugin and PoVerCat may be declared in either order. PoVerCat waits for a
+supported Kotlin plugin before configuring source sets and compilation tasks.
+
 ### Configure the plugin (Optional)
 
-By default, the plugin looks for the `libs.versions.toml` file in the gradle directory, which is the standard location for the version catalog. However, you can override this behavior or specify multiple sources—each of which will be transformed into a separate Java class.
+By default, the plugin looks for the `libs.versions.toml` file in the gradle directory, which is the standard location for the version catalog. However, you can override this behavior or specify multiple sources—each of which will be transformed into a separate Kotlin class.
 
 The default package for the generated classes is `org.gradle.version.catalog`. This too can be customized via plugin configuration.
 
@@ -91,7 +113,7 @@ dependencies {
 }
 ```
 
-Once the dependency is in place, you can use the version values directly in your code:
+Once the dependency is in place, Kotlin consumers can use the version values directly:
 
 ```kotlin
 fun configureExtensions(extensions: ExtensionContainer, project: Project) {
@@ -99,6 +121,12 @@ fun configureExtensions(extensions: ExtensionContainer, project: Project) {
         toolVersion = LibsVersions.Libraries.jacocoTool.version!!
     }
 }
+```
+
+The same compiled catalog can be used from Java:
+
+```java
+String jacocoVersion = LibsVersions.Libraries.getJacocoTool().getVersion();
 ```
 
 This approach allows you to build convention plugins with preconfigured tools using centralized version definitions that are consistent across your project ecosystem.

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPlugin.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPlugin.kt
@@ -15,11 +15,12 @@
 
 package com.the13haven.gradle.povercat
 
-import org.gradle.api.Plugin
-import org.gradle.api.Project
-import org.gradle.kotlin.dsl.get
 import com.the13haven.gradle.povercat.PortableVersionCatalogGeneratorPluginExtension.Companion.portableVersionCatalog
 import com.the13haven.gradle.povercat.PortableVersionCatalogGeneratorPluginTask.Companion.generatePortableVersionCatalogTask
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSetContainer
 
 
 /**
@@ -37,16 +38,47 @@ abstract class PortableVersionCatalogGeneratorPlugin : Plugin<Project> {
         // register task
         val task = project.generatePortableVersionCatalogTask(extension)
 
-        // arrange tasks in a sequential chain
-        project.tasks
-            .named("compileKotlin") {
+        var kotlinIntegrationConfigured = false
+
+        fun configureKotlinIntegration() {
+            if (kotlinIntegrationConfigured) {
+                return
+            }
+
+            kotlinIntegrationConfigured = true
+
+            project.tasks.named("compileKotlin") {
                 dependsOn(task)
             }
 
-        project.extensions
-            .getByType(org.gradle.api.tasks.SourceSetContainer::class.java)["main"]
-            .java {
-                srcDir(extension.outputDir)
+            project.extensions
+                .getByType(SourceSetContainer::class.java)
+                .named("main") {
+                    java.srcDir(task.flatMap { it.outputDir })
+                }
+        }
+
+        SUPPORTED_KOTLIN_PLUGIN_IDS.forEach { pluginId ->
+            project.pluginManager.withPlugin(pluginId) {
+                configureKotlinIntegration()
             }
+        }
+
+        project.afterEvaluate {
+            if (!kotlinIntegrationConfigured) {
+                throw GradleException(KOTLIN_PLUGIN_REQUIRED_MESSAGE)
+            }
+        }
+    }
+
+    companion object {
+        private val SUPPORTED_KOTLIN_PLUGIN_IDS = listOf(
+            "org.gradle.kotlin.kotlin-dsl",
+            "org.jetbrains.kotlin.jvm"
+        )
+
+        internal const val KOTLIN_PLUGIN_REQUIRED_MESSAGE =
+            "PoVerCat requires the Kotlin DSL ('kotlin-dsl') or Kotlin JVM " +
+                    "('org.jetbrains.kotlin.jvm') plugin in the catalog producer project."
     }
 }

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
@@ -54,7 +54,7 @@ class PortableVersionCatalogGeneratorPluginTest {
             .withProjectDir(projectDir)
             .withPluginClasspath()
             .withArguments(
-                "generatePortableVersionCatalog",
+                "compileKotlin",
                 "--configuration-cache",
                 "--configuration-cache-problems=fail"
             )
@@ -82,6 +82,9 @@ class PortableVersionCatalogGeneratorPluginTest {
         val generatedCatalog = generatedDir.resolve("com/example/catalog/VersionsCatalog.kt")
         assertTrue(generatedCatalog.exists())
         assertTrue(generatedCatalog.readText().contains("@version v1.2.3"))
+        assertTrue(
+            projectDir.resolve("build/classes/kotlin/main/com/example/catalog/Versions.class").exists()
+        )
 
         // 6. Change a declared task input and verify the catalog is regenerated
         writeBuildFile(projectVersion = "2.0.0")
@@ -94,14 +97,39 @@ class PortableVersionCatalogGeneratorPluginTest {
         assertTrue(generatedCatalog.readText().contains("@version v2.0.0"))
     }
 
+    @Test
+    fun `fail with clear message when producer has no supported Kotlin plugin`() {
+        projectDir.resolve("build.gradle.kts").writeText(
+            """
+            plugins {
+                id("com.the13haven.povercat")
+            }
+            """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("tasks")
+            .buildAndFail()
+
+        assertTrue(
+            result.output.contains(PortableVersionCatalogGeneratorPlugin.KOTLIN_PLUGIN_REQUIRED_MESSAGE)
+        )
+    }
+
     private fun writeBuildFile(projectVersion: String = "1.2.3") {
         val buildFile = projectDir.resolve("build.gradle.kts")
         buildFile.writeText(
             """
             plugins {
-                `kotlin-dsl`
                 id("jacoco-testkit-coverage")
                 id("com.the13haven.povercat")
+                `kotlin-dsl`
+            }
+
+            repositories {
+                mavenCentral()
             }
 
             portableVersionCatalog {


### PR DESCRIPTION
## Summary
- wait for the Kotlin DSL or Kotlin JVM plugin before wiring generated sources and `compileKotlin`
- support applying PoVerCat before or after the supported Kotlin plugin
- fail with an actionable message when the producer has no supported Kotlin plugin
- wire the generated source directory from the generator task output provider
- clarify producer/consumer Java and Kotlin compatibility in README
- correct the plugin ID in the usage example

## Verification
- `./gradlew :plugin:test --tests "com.the13haven.gradle.povercat.PortableVersionCatalogGeneratorPluginTest" --rerun-tasks --console=plain`
- `./gradlew clean check --rerun-tasks --console=plain`
- functional test applies PoVerCat before `kotlin-dsl`, compiles the generated class, and reuses the configuration cache