### PR TITLE
Manage generated catalog outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,25 @@ supported Kotlin plugin before configuring source sets and compilation tasks.
 
 ### Configure the plugin (Optional)
 
-By default, the plugin looks for the `libs.versions.toml` file in the gradle directory, which is the standard location for the version catalog. However, you can override this behavior or specify multiple sources—each of which will be transformed into a separate Kotlin class.
+By default, the plugin looks for `gradle/libs.versions.toml`, the standard version
+catalog location. If the default file, or any explicitly configured catalog file,
+does not exist, generation fails with an error. You can override the default or
+specify multiple sources—each of which will be transformed into a separate Kotlin
+class.
+
+To intentionally disable generation, explicitly configure an empty file collection:
+
+```kotlin
+portableVersionCatalog {
+    tomlFiles.setFrom(emptyList<Any>())
+}
+```
+
+With an empty collection, the generation task is skipped when there are no outputs
+to clean up. PoVerCat tracks the files it owns in
+`build/generated/sources/.povercat-generated-files` and removes obsolete generated
+classes when a configured catalog is removed or renamed. Do not edit this manifest
+manually.
 
 The default package for the generated classes is `org.gradle.version.catalog`. This too can be customized via plugin configuration.
 

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTask.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTask.kt
@@ -16,6 +16,7 @@
 package com.the13haven.gradle.povercat
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
@@ -25,12 +26,14 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
 import org.gradle.work.DisableCachingByDefault
 import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.Locale
 
 /**
@@ -39,7 +42,7 @@ import java.util.Locale
  * @author ssidorov@the13haven.com
  */
 @DisableCachingByDefault(
-    because = "The task does not remove stale generated sources when an input catalog is removed"
+    because = "Generated source includes the current year, which is not declared as a task input"
 )
 abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
 
@@ -49,7 +52,6 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
     @get:Input
     abstract val projectVersion: Property<String>
 
-    @get:SkipWhenEmpty
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val tomlFiles: ConfigurableFileCollection
@@ -59,32 +61,34 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
 
     @TaskAction
     fun executeTask() {
+        val configuredTomlFiles = tomlFiles.files
 
-        val outputDirectory = File(
-            outputDir.get().asFile.path +
-                    File.separator +
-                    catalogPackage.get()
-                        .split(".")
-                        .joinToString(File.separator)
-        )
-
-        if (!outputDirectory.exists()) {
-            outputDirectory.mkdirs()
-        }
-
-        val filteredTomlFiles = tomlFiles.files
-            .map { tomlFile ->
-                if (!tomlFile.exists()) {
-                    throw IllegalStateException("Version catalog file not found: ${tomlFile.absolutePath}")
-                }
-
-                tomlFile
+        configuredTomlFiles
+            .filterNot(File::exists)
+            .takeIf { it.isNotEmpty() }
+            ?.let { missingFiles ->
+                throw GradleException(
+                    missingFiles.joinToString(
+                        prefix = "Version catalog file not found: ",
+                        separator = ", "
+                    ) { it.absolutePath }
+                )
             }
+
+        val filteredTomlFiles = configuredTomlFiles
             .filter { file -> file.extension == "toml" }
 
-        filteredTomlFiles.forEach { tomlFile ->
+        val outputRoot = outputDir.get().asFile
+            .toPath()
+            .toAbsolutePath()
+            .normalize()
+        val packagePath = catalogPackage.get()
+            .split(".")
+            .joinToString("/")
+
+        val generatedSources = filteredTomlFiles.mapNotNull { tomlFile ->
             val className = TomlParserUtils.toCamelCase(tomlFile.nameWithoutExtension)
-                .replaceFirstChar { it.uppercase(Locale.getDefault()) }
+                .replaceFirstChar { it.uppercase(Locale.ROOT) }
 
             val classContent = PortableVersionCatalogClassGenerator.generateClass(
                 tomlFile,
@@ -94,13 +98,118 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
             )
 
             if (classContent.isNotBlank()) {
-                val outputFile = File(outputDirectory, "${className}Catalog.kt")
-                outputFile.writeText(classContent)
+                val relativePath = "$packagePath/${className}Catalog.kt"
+                relativePath to classContent
+            } else {
+                null
             }
+        }.toMap()
+
+        val previousGeneratedFiles = readPreviousGeneratedFiles(outputRoot)
+        val currentGeneratedFiles = generatedSources.keys
+
+        (previousGeneratedFiles - currentGeneratedFiles).forEach { relativePath ->
+            val staleOutput = resolveOwnedOutput(outputRoot, relativePath)
+            Files.deleteIfExists(staleOutput)
+            deleteEmptyParentDirectories(staleOutput.parent, outputRoot)
+        }
+
+        generatedSources.forEach { (relativePath, classContent) ->
+            val outputFile = resolveOwnedOutput(outputRoot, relativePath)
+            Files.createDirectories(outputFile.parent)
+            Files.writeString(outputFile, classContent, StandardCharsets.UTF_8)
+        }
+
+        updateManifest(outputRoot, currentGeneratedFiles)
+    }
+
+    internal fun hasConfiguredCatalogsOrPreviousOutputs(): Boolean {
+        if (tomlFiles.files.isNotEmpty() || manifestFile().exists()) {
+            return true
+        }
+
+        val outputRoot = outputDir.get().asFile.toPath().toAbsolutePath().normalize()
+        return discoverLegacyGeneratedFiles(outputRoot).isNotEmpty()
+    }
+
+    private fun readPreviousGeneratedFiles(outputRoot: Path): Set<String> {
+        val manifest = manifestFile()
+        if (manifest.exists()) {
+            return manifest.readLines(StandardCharsets.UTF_8)
+                .map(String::trim)
+                .filter(String::isNotEmpty)
+                .toSet()
+        }
+
+        return discoverLegacyGeneratedFiles(outputRoot)
+    }
+
+    private fun discoverLegacyGeneratedFiles(outputRoot: Path): Set<String> {
+        val outputRootFile = outputRoot.toFile()
+        if (!outputRootFile.exists()) {
+            return emptySet()
+        }
+
+        return outputRootFile.walkTopDown()
+            .filter(File::isFile)
+            .filter { it.extension == "kt" }
+            .filter { it.readText().contains(GENERATED_SOURCE_MARKER) }
+            .map { generatedFile ->
+                outputRoot.relativize(generatedFile.toPath().toAbsolutePath().normalize())
+                    .toString()
+                    .replace(File.separatorChar, '/')
+            }
+            .toSet()
+    }
+
+    private fun updateManifest(outputRoot: Path, generatedFiles: Set<String>) {
+        val manifest = manifestFile().toPath()
+
+        if (generatedFiles.isEmpty()) {
+            Files.deleteIfExists(manifest)
+            return
+        }
+
+        Files.createDirectories(outputRoot)
+        Files.writeString(
+            manifest,
+            generatedFiles.sorted().joinToString(separator = "\n", postfix = "\n"),
+            StandardCharsets.UTF_8
+        )
+    }
+
+    private fun resolveOwnedOutput(outputRoot: Path, relativePath: String): Path {
+        val outputFile = outputRoot.resolve(relativePath).normalize()
+        if (!outputFile.startsWith(outputRoot)) {
+            throw GradleException("Invalid entry in PoVerCat generated files manifest: $relativePath")
+        }
+
+        return outputFile
+    }
+
+    private fun deleteEmptyParentDirectories(startDirectory: Path?, outputRoot: Path) {
+        var currentDirectory = startDirectory
+
+        while (currentDirectory != null && currentDirectory != outputRoot) {
+            val isEmpty = Files.isDirectory(currentDirectory) &&
+                    Files.list(currentDirectory).use { entries -> entries.findAny().isEmpty }
+            if (!isEmpty) {
+                return
+            }
+
+            Files.deleteIfExists(currentDirectory)
+            currentDirectory = currentDirectory.parent
         }
     }
 
+    private fun manifestFile(): File =
+        outputDir.file(GENERATED_FILES_MANIFEST).get().asFile
+
     companion object {
+        internal const val GENERATED_FILES_MANIFEST = ".povercat-generated-files"
+        private const val GENERATED_SOURCE_MARKER =
+            "WARNING: This class is auto-generated by PoVerCat plugin."
+
         fun Project.generatePortableVersionCatalogTask(extension: PortableVersionCatalogGeneratorPluginExtension): TaskProvider<PortableVersionCatalogGeneratorPluginTask> {
             val projectVersionProvider = provider { version.toString() }
 
@@ -109,6 +218,10 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
                 projectVersion.set(projectVersionProvider)
                 tomlFiles.setFrom(extension.tomlFiles)
                 outputDir.set(extension.outputDir)
+
+                onlyIf("No version catalog files configured") {
+                    hasConfiguredCatalogsOrPreviousOutputs()
+                }
             }
         }
     }

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTaskTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTaskTest.kt
@@ -19,8 +19,10 @@ import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockkObject
 import org.gradle.api.Project
+import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -56,25 +58,18 @@ class PortableVersionCatalogGeneratorPluginTaskTest {
     }
 
     @Test
-    fun `should create output directory if not exists`() {
-        val mockFile = File(tempDir, "com/example/catalog")
-        assertTrue(!mockFile.exists())
-
-        task.get().executeTask()
-
-        assertTrue(mockFile.exists())
+    fun `should not require work when no catalogs or previous outputs exist`() {
+        assertFalse(task.get().hasConfiguredCatalogsOrPreviousOutputs())
     }
 
     @Test
-    fun `should skip creating output directory if exist`() {
-        val mockFile = File(tempDir, "com/example/catalog")
-        mockFile.mkdirs()
+    fun `should require work when previous outputs manifest exists`() {
+        File(
+            tempDir,
+            PortableVersionCatalogGeneratorPluginTask.GENERATED_FILES_MANIFEST
+        ).writeText("com/example/catalog/StaleCatalog.kt\n")
 
-        assertTrue(mockFile.exists())
-
-        task.get().executeTask()
-
-        assertTrue(mockFile.exists())
+        assertTrue(task.get().hasConfiguredCatalogsOrPreviousOutputs())
     }
 
     @Test
@@ -83,11 +78,11 @@ class PortableVersionCatalogGeneratorPluginTaskTest {
 
         task.get().tomlFiles.setFrom(missingFile)
 
-        val exception = assertThrows<IllegalStateException> {
+        val exception = assertThrows<GradleException> {
             task.get().executeTask()
         }
 
-        assertTrue(exception.message!!.contains("Version catalog file not found"))
+        assertTrue(exception.message!!.contains(missingFile.absolutePath))
     }
 
     @Test
@@ -114,6 +109,33 @@ class PortableVersionCatalogGeneratorPluginTaskTest {
         val generatedFile = File(tempDir, "com/example/catalog/ValidCatalog.kt")
         assertTrue(generatedFile.exists())
         assertTrue(generatedFile.readText().contains("class Valid {}"))
+        assertEquals(
+            "com/example/catalog/ValidCatalog.kt\n",
+            File(
+                tempDir,
+                PortableVersionCatalogGeneratorPluginTask.GENERATED_FILES_MANIFEST
+            ).readText()
+        )
+    }
+
+    @Test
+    fun `should delete stale generated files listed in manifest`() {
+        val staleFile = File(tempDir, "com/example/catalog/StaleCatalog.kt").apply {
+            parentFile.mkdirs()
+            writeText("class StaleCatalog")
+        }
+        val manifest = File(
+            tempDir,
+            PortableVersionCatalogGeneratorPluginTask.GENERATED_FILES_MANIFEST
+        ).apply {
+            writeText("com/example/catalog/StaleCatalog.kt\n")
+        }
+
+        task.get().executeTask()
+
+        assertFalse(staleFile.exists())
+        assertFalse(manifest.exists())
+        assertFalse(File(tempDir, "com").exists())
     }
 
     @Test
@@ -137,7 +159,13 @@ class PortableVersionCatalogGeneratorPluginTaskTest {
 
         task.get().executeTask()
 
-        val generatedFile = File(tempDir, "com/example/catalog/TestEmpty.kt")
+        val generatedFile = File(tempDir, "com/example/catalog/TestEmptyCatalog.kt")
         assertFalse(generatedFile.exists())
+        assertFalse(
+            File(
+                tempDir,
+                PortableVersionCatalogGeneratorPluginTask.GENERATED_FILES_MANIFEST
+            ).exists()
+        )
     }
 }

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
@@ -18,6 +18,7 @@ package com.the13haven.gradle.povercat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -33,7 +34,7 @@ class PortableVersionCatalogGeneratorPluginTest {
     @TempDir
     lateinit var projectDir: File
 
-    val versionsFileName = "versions.toml"
+    private val versionsFileName = "versions.toml"
 
     @Test
     fun `generate catalog with reusable configuration cache`() {
@@ -118,7 +119,112 @@ class PortableVersionCatalogGeneratorPluginTest {
         )
     }
 
-    private fun writeBuildFile(projectVersion: String = "1.2.3") {
+    @Test
+    fun `skip generation when catalogs are explicitly empty`() {
+        writeBuildFile(tomlFiles = emptyList())
+
+        val result = runner("generatePortableVersionCatalog").build()
+
+        assertEquals(
+            TaskOutcome.SKIPPED,
+            result.task(":generatePortableVersionCatalog")?.outcome
+        )
+        assertFalse(projectDir.resolve("build/generated/sources").exists())
+    }
+
+    @Test
+    fun `fail when default catalog does not exist`() {
+        writeBuildFile(tomlFiles = null)
+
+        val result = runner("generatePortableVersionCatalog").buildAndFail()
+
+        assertTrue(result.output.contains("gradle/libs.versions.toml"))
+        assertTrue(result.output.contains("Version catalog file not found"))
+    }
+
+    @Test
+    fun `fail when configured catalog does not exist`() {
+        val missingCatalog = projectDir.resolve("catalog/missing.toml")
+        writeBuildFile(tomlFiles = listOf(missingCatalog))
+
+        val result = runner("generatePortableVersionCatalog").buildAndFail()
+
+        assertTrue(result.output.contains(missingCatalog.absolutePath))
+        assertTrue(result.output.contains("Version catalog file not found"))
+    }
+
+    @Test
+    fun `remove stale generated sources when catalogs change`() {
+        val firstCatalog = projectDir.resolve("first.toml")
+        val secondCatalog = projectDir.resolve("second.toml")
+        writeMinimalTomlFile(firstCatalog)
+        writeMinimalTomlFile(secondCatalog)
+        writeBuildFile(tomlFiles = listOf(firstCatalog, secondCatalog))
+
+        val generatedDir = projectDir.resolve("build/generated/sources")
+        val firstSource = generatedDir.resolve("com/example/catalog/FirstCatalog.kt")
+        val secondSource = generatedDir.resolve("com/example/catalog/SecondCatalog.kt")
+        val manifest = generatedDir.resolve(
+            PortableVersionCatalogGeneratorPluginTask.GENERATED_FILES_MANIFEST
+        )
+
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            runner("generatePortableVersionCatalog")
+                .build()
+                .task(":generatePortableVersionCatalog")
+                ?.outcome
+        )
+        assertTrue(firstSource.exists())
+        assertTrue(secondSource.exists())
+        assertTrue(manifest.exists())
+
+        writeBuildFile(tomlFiles = listOf(firstCatalog))
+        runner("generatePortableVersionCatalog").build()
+        assertTrue(firstSource.exists())
+        assertFalse(secondSource.exists())
+
+        val renamedCatalog = projectDir.resolve("renamed.toml")
+        assertTrue(firstCatalog.renameTo(renamedCatalog))
+        writeBuildFile(tomlFiles = listOf(renamedCatalog))
+        runner("generatePortableVersionCatalog").build()
+
+        val renamedSource = generatedDir.resolve("com/example/catalog/RenamedCatalog.kt")
+        assertFalse(firstSource.exists())
+        assertTrue(renamedSource.exists())
+
+        writeBuildFile(tomlFiles = emptyList())
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            runner("generatePortableVersionCatalog")
+                .build()
+                .task(":generatePortableVersionCatalog")
+                ?.outcome
+        )
+        assertFalse(renamedSource.exists())
+        assertFalse(manifest.exists())
+
+        assertEquals(
+            TaskOutcome.SKIPPED,
+            runner("generatePortableVersionCatalog")
+                .build()
+                .task(":generatePortableVersionCatalog")
+                ?.outcome
+        )
+    }
+
+    private fun writeBuildFile(
+        projectVersion: String = "1.2.3",
+        tomlFiles: List<File>? = listOf(projectDir.resolve(versionsFileName))
+    ) {
+        val tomlFilesConfiguration = when {
+            tomlFiles == null -> ""
+            tomlFiles.isEmpty() -> "tomlFiles.setFrom(emptyList<Any>())"
+            else -> tomlFiles.joinToString(
+                prefix = "tomlFiles.setFrom(listOf(",
+                postfix = "))"
+            ) { "\"${it.absolutePath}\"" }
+        }
         val buildFile = projectDir.resolve("build.gradle.kts")
         buildFile.writeText(
             """
@@ -134,7 +240,7 @@ class PortableVersionCatalogGeneratorPluginTest {
 
             portableVersionCatalog {
                 catalogPackage.set("com.example.catalog")
-                tomlFiles.setFrom("${projectDir.absolutePath}/${versionsFileName}")
+                $tomlFilesConfiguration
                 outputDir.set(file("build/generated/sources"))
             }
 
@@ -142,6 +248,12 @@ class PortableVersionCatalogGeneratorPluginTest {
             """.trimIndent()
         )
     }
+
+    private fun runner(vararg arguments: String): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments(*arguments)
 
     private fun writeTomlFile() {
         val tomlFile = projectDir.resolve(versionsFileName)
@@ -173,6 +285,15 @@ class PortableVersionCatalogGeneratorPluginTest {
             plugin-version-ref = { id = "com.test.plugin-version-ref", version.ref = "version-simple" }
             plugin-version-as-object = { id = "com.test.version-as-object", version = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] } }
             plugin-simple-id.id = "com.text.plugin-with-id"
+            """.trimIndent()
+        )
+    }
+
+    private fun writeMinimalTomlFile(file: File) {
+        file.writeText(
+            """
+            [versions]
+            kotlin = "2.3.0"
             """.trimIndent()
         )
     }


### PR DESCRIPTION
## Summary
- distinguish an explicitly empty TOML collection from missing configured/default catalogs
- track generated source ownership and remove stale classes after catalog removal or rename
- document the behavior and add unit plus Gradle TestKit coverage

## Verification
- `./gradlew clean check`