### PR TITLE
Support explicit catalog class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,39 @@ portableVersionCatalog {
 }
 ```
 
+#### Configure generated class names
+
+By default, each generated Kotlin class name is derived from its TOML file name.
+For example, `libs-main.versions.toml` produces `LibsMainVersions`.
+
+Use `catalogClassNames` when you need a stable, explicit public class name:
+
+```kotlin
+portableVersionCatalog {
+    tomlFiles.setFrom(
+        "catalog/team-a/libs-main.toml",
+        "catalog/team-b/libs_main.toml"
+    )
+
+    catalogClassNames.put(
+        "catalog/team-a/libs-main.toml",
+        "TeamAVersions"
+    )
+    catalogClassNames.put(
+        "catalog/team-b/libs_main.toml",
+        "TeamBVersions"
+    )
+}
+```
+
+Keys may be project-relative paths (recommended) or absolute paths and must refer
+to files present in `tomlFiles`. Values are the exact generated Kotlin class names
+and must be valid Kotlin and Java identifiers.
+
+If multiple TOML file names resolve to the same generated class name, generation
+fails instead of silently overwriting a source file. Resolve the collision by
+renaming the files or assigning unique names through `catalogClassNames`.
+
 ### Run the Task
 
 By default, the plugin is executed automatically before the `compileKotlin` task. However, you can also trigger it manually using the `generatePortableVersionCatalog` task:

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginExtension.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginExtension.kt
@@ -18,6 +18,7 @@ package com.the13haven.gradle.povercat
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 
 /**
@@ -34,6 +35,13 @@ open class PortableVersionCatalogGeneratorPluginExtension(project: Project) {
     val tomlFiles: ConfigurableFileCollection = project.objects
         .fileCollection()
         .convention("gradle/libs.versions.toml")
+
+    /**
+     * Explicit generated class names keyed by a project-relative or absolute TOML file path.
+     */
+    val catalogClassNames: MapProperty<String, String> = project.objects
+        .mapProperty(String::class.java, String::class.java)
+        .convention(emptyMap())
 
     val outputDir: DirectoryProperty = project.objects
         .directoryProperty()

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTask.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTask.kt
@@ -20,9 +20,11 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -35,6 +37,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Locale
+import javax.lang.model.SourceVersion
 
 /**
  * PoVerCat Plugin Task.
@@ -55,6 +58,12 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val tomlFiles: ConfigurableFileCollection
+
+    @get:Input
+    abstract val catalogClassNames: MapProperty<String, String>
+
+    @get:Internal
+    abstract val projectDirectory: DirectoryProperty
 
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty
@@ -86,20 +95,17 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
             .split(".")
             .joinToString("/")
 
-        val generatedSources = filteredTomlFiles.mapNotNull { tomlFile ->
-            val className = TomlParserUtils.toCamelCase(tomlFile.nameWithoutExtension)
-                .replaceFirstChar { it.uppercase(Locale.ROOT) }
-
+        val catalogInputs = resolveCatalogInputs(filteredTomlFiles, packagePath)
+        val generatedSources = catalogInputs.mapNotNull { catalogInput ->
             val classContent = PortableVersionCatalogClassGenerator.generateClass(
-                tomlFile,
+                catalogInput.file,
                 catalogPackage.get(),
-                className,
+                catalogInput.className,
                 projectVersion.get()
             )
 
             if (classContent.isNotBlank()) {
-                val relativePath = "$packagePath/${className}Catalog.kt"
-                relativePath to classContent
+                catalogInput.relativeOutputPath to classContent
             } else {
                 null
             }
@@ -123,8 +129,124 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
         updateManifest(outputRoot, currentGeneratedFiles)
     }
 
+    private fun resolveCatalogInputs(tomlFiles: List<File>, packagePath: String): List<CatalogInput> {
+        val projectRoot = normalizeFilePath(projectDirectory.get().asFile)
+        val configuredFilePaths = tomlFiles.mapTo(mutableSetOf(), ::normalizeFilePath)
+        val overridesByPath = resolveClassNameOverrides(projectRoot)
+        val unknownOverrides = overridesByPath.keys - configuredFilePaths
+
+        if (unknownOverrides.isNotEmpty()) {
+            throw GradleException(
+                unknownOverrides
+                    .sortedBy(Path::toString)
+                    .joinToString(
+                        prefix = "Catalog class name configured for a file that is not in tomlFiles: ",
+                        separator = ", "
+                    )
+            )
+        }
+
+        val catalogInputs = tomlFiles.map { tomlFile ->
+            val className = overridesByPath[normalizeFilePath(tomlFile)]
+                ?: defaultClassName(tomlFile)
+            validateClassName(className, tomlFile)
+
+            CatalogInput(
+                file = tomlFile,
+                className = className,
+                relativeOutputPath = "$packagePath/${className}Catalog.kt"
+            )
+        }
+
+        validateUniqueClassNames(catalogInputs)
+        return catalogInputs
+    }
+
+    private fun resolveClassNameOverrides(projectRoot: Path): Map<Path, String> {
+        val normalizedOverrides = catalogClassNames.get()
+            .entries
+            .groupBy { (configuredPath) ->
+                val path = Path.of(configuredPath)
+                normalizeFilePath(
+                    (if (path.isAbsolute) path else projectRoot.resolve(path)).toFile()
+                )
+            }
+
+        val duplicatePaths = normalizedOverrides.filterValues { it.size > 1 }
+        if (duplicatePaths.isNotEmpty()) {
+            throw GradleException(
+                duplicatePaths.entries.joinToString(
+                    prefix = "Multiple catalogClassNames entries refer to the same file: ",
+                    separator = ", "
+                ) { (path, entries) ->
+                    "$path (${entries.joinToString { it.key }})"
+                }
+            )
+        }
+
+        return normalizedOverrides.mapValues { (_, entries) -> entries.single().value }
+    }
+
+    private fun defaultClassName(tomlFile: File): String =
+        TomlParserUtils.toCamelCase(tomlFile.nameWithoutExtension)
+            .replaceFirstChar { it.uppercase(Locale.ROOT) }
+
+    private fun validateClassName(className: String, tomlFile: File) {
+        if (
+            !VALID_CLASS_NAME.matches(className) ||
+            className in KOTLIN_KEYWORDS ||
+            SourceVersion.isKeyword(className)
+        ) {
+            throw GradleException(
+                "Invalid generated catalog class name '$className' for ${tomlFile.absolutePath}. " +
+                        "Configure catalogClassNames with a valid Kotlin and Java class name."
+            )
+        }
+    }
+
+    private fun validateUniqueClassNames(catalogInputs: List<CatalogInput>) {
+        val collisions = catalogInputs
+            .groupBy { it.relativeOutputPath.lowercase(Locale.ROOT) }
+            .values
+            .filter { it.size > 1 }
+
+        if (collisions.isEmpty()) {
+            return
+        }
+
+        val details = collisions.joinToString(separator = "\n\n") { conflictingInputs ->
+            val generatedNames = conflictingInputs
+                .map(CatalogInput::className)
+                .distinct()
+                .joinToString()
+            conflictingInputs
+                .map { it.file.absolutePath }
+                .sorted()
+                .joinToString(
+                    prefix = "Generated class '$generatedNames' conflicts for:\n",
+                    separator = "\n"
+                ) { "- $it" }
+        }
+
+        throw GradleException(
+            "Multiple version catalogs generate conflicting class names:\n" +
+                    "$details\n\n" +
+                    "Rename the catalog files or configure unique names with catalogClassNames, for example:\n" +
+                    "portableVersionCatalog {\n" +
+                    "    catalogClassNames.put(\"path/to/catalog.toml\", \"CustomCatalogName\")\n" +
+                    "}"
+        )
+    }
+
+    private fun normalizeFilePath(file: File): Path =
+        file.canonicalFile.toPath()
+
     internal fun hasConfiguredCatalogsOrPreviousOutputs(): Boolean {
-        if (tomlFiles.files.isNotEmpty() || manifestFile().exists()) {
+        if (
+            tomlFiles.files.isNotEmpty() ||
+            catalogClassNames.get().isNotEmpty() ||
+            manifestFile().exists()
+        ) {
             return true
         }
 
@@ -209,6 +331,83 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
         internal const val GENERATED_FILES_MANIFEST = ".povercat-generated-files"
         private const val GENERATED_SOURCE_MARKER =
             "WARNING: This class is auto-generated by PoVerCat plugin."
+        private val VALID_CLASS_NAME = Regex("[A-Za-z_][A-Za-z0-9_]*")
+        private val KOTLIN_KEYWORDS = setOf(
+            "as",
+            "abstract",
+            "actual",
+            "annotation",
+            "break",
+            "by",
+            "catch",
+            "class",
+            "companion",
+            "const",
+            "constructor",
+            "continue",
+            "crossinline",
+            "data",
+            "delegate",
+            "do",
+            "dynamic",
+            "else",
+            "enum",
+            "expect",
+            "external",
+            "false",
+            "field",
+            "file",
+            "final",
+            "finally",
+            "for",
+            "fun",
+            "get",
+            "if",
+            "import",
+            "in",
+            "infix",
+            "init",
+            "inline",
+            "inner",
+            "interface",
+            "internal",
+            "is",
+            "lateinit",
+            "noinline",
+            "null",
+            "object",
+            "open",
+            "operator",
+            "out",
+            "override",
+            "package",
+            "param",
+            "private",
+            "property",
+            "protected",
+            "public",
+            "receiver",
+            "reified",
+            "return",
+            "sealed",
+            "set",
+            "setparam",
+            "super",
+            "suspend",
+            "tailrec",
+            "this",
+            "throw",
+            "true",
+            "try",
+            "typealias",
+            "typeof",
+            "val",
+            "var",
+            "vararg",
+            "when",
+            "where",
+            "while"
+        )
 
         fun Project.generatePortableVersionCatalogTask(extension: PortableVersionCatalogGeneratorPluginExtension): TaskProvider<PortableVersionCatalogGeneratorPluginTask> {
             val projectVersionProvider = provider { version.toString() }
@@ -217,6 +416,8 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
                 catalogPackage.set(extension.catalogPackage)
                 projectVersion.set(projectVersionProvider)
                 tomlFiles.setFrom(extension.tomlFiles)
+                catalogClassNames.set(extension.catalogClassNames)
+                projectDirectory.set(layout.projectDirectory)
                 outputDir.set(extension.outputDir)
 
                 onlyIf("No version catalog files configured") {
@@ -225,4 +426,10 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
             }
         }
     }
+
+    private data class CatalogInput(
+        val file: File,
+        val className: String,
+        val relativeOutputPath: String
+    )
 }

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginExtensionTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginExtensionTest.kt
@@ -59,6 +59,21 @@ class PortableVersionCatalogGeneratorPluginExtensionTest {
     }
 
     @Test
+    fun `should have empty catalog class names by default`() {
+        assertTrue(extension.catalogClassNames.get().isEmpty())
+    }
+
+    @Test
+    fun `should allow setting catalog class name`() {
+        extension.catalogClassNames.put("custom.versions.toml", "CustomVersions")
+
+        assertEquals(
+            "CustomVersions",
+            extension.catalogClassNames.get()["custom.versions.toml"]
+        )
+    }
+
+    @Test
     fun `should have default outputDir value`() {
         val expectedDir = project.layout.buildDirectory.dir("build/generated/sources").get().asFile
         assertEquals(expectedDir, extension.outputDir.get().asFile)

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTaskTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTaskTest.kt
@@ -54,6 +54,8 @@ class PortableVersionCatalogGeneratorPluginTaskTest {
 
         task.get().catalogPackage.set("com.example.catalog")
         task.get().projectVersion.set("1.0.0")
+        task.get().catalogClassNames.convention(emptyMap())
+        task.get().projectDirectory.set(tempDir)
         task.get().outputDir.set(tempDir)
     }
 
@@ -68,6 +70,13 @@ class PortableVersionCatalogGeneratorPluginTaskTest {
             tempDir,
             PortableVersionCatalogGeneratorPluginTask.GENERATED_FILES_MANIFEST
         ).writeText("com/example/catalog/StaleCatalog.kt\n")
+
+        assertTrue(task.get().hasConfiguredCatalogsOrPreviousOutputs())
+    }
+
+    @Test
+    fun `should require work when class name is configured without catalog file`() {
+        task.get().catalogClassNames.put("missing.toml", "MissingVersions")
 
         assertTrue(task.get().hasConfiguredCatalogsOrPreviousOutputs())
     }
@@ -116,6 +125,73 @@ class PortableVersionCatalogGeneratorPluginTaskTest {
                 PortableVersionCatalogGeneratorPluginTask.GENERATED_FILES_MANIFEST
             ).readText()
         )
+    }
+
+    @Test
+    fun `should use explicitly configured catalog class name`() {
+        val catalogFile = File(tempDir, "custom.toml").apply { writeText("[versions]") }
+        task.get().tomlFiles.setFrom(catalogFile)
+        task.get().catalogClassNames.put("custom.toml", "CompanyVersions")
+
+        mockkObject(PortableVersionCatalogClassGenerator)
+        every {
+            PortableVersionCatalogClassGenerator.generateClass(
+                catalogFile,
+                "com.example.catalog",
+                "CompanyVersions",
+                "1.0.0"
+            )
+        } returns "class CompanyVersions {}"
+
+        task.get().executeTask()
+
+        val generatedFile = File(tempDir, "com/example/catalog/CompanyVersionsCatalog.kt")
+        assertTrue(generatedFile.exists())
+        assertTrue(generatedFile.readText().contains("class CompanyVersions {}"))
+    }
+
+    @Test
+    fun `should fail with actionable message when generated class names collide`() {
+        val firstCatalog = File(tempDir, "libs-main.toml").apply { writeText("[versions]") }
+        val secondCatalog = File(tempDir, "libs_main.toml").apply { writeText("[versions]") }
+        task.get().tomlFiles.setFrom(firstCatalog, secondCatalog)
+
+        val exception = assertThrows<GradleException> {
+            task.get().executeTask()
+        }
+
+        assertTrue(exception.message!!.contains("Multiple version catalogs"))
+        assertTrue(exception.message!!.contains(firstCatalog.absolutePath))
+        assertTrue(exception.message!!.contains(secondCatalog.absolutePath))
+        assertTrue(exception.message!!.contains("catalogClassNames"))
+    }
+
+    @Test
+    fun `should reject invalid explicit catalog class name`() {
+        val catalogFile = File(tempDir, "custom.toml").apply { writeText("[versions]") }
+        task.get().tomlFiles.setFrom(catalogFile)
+        task.get().catalogClassNames.put("custom.toml", "invalid-name")
+
+        val exception = assertThrows<GradleException> {
+            task.get().executeTask()
+        }
+
+        assertTrue(exception.message!!.contains("Invalid generated catalog class name"))
+        assertTrue(exception.message!!.contains("invalid-name"))
+    }
+
+    @Test
+    fun `should reject class name configured for file outside toml files`() {
+        val catalogFile = File(tempDir, "custom.toml").apply { writeText("[versions]") }
+        task.get().tomlFiles.setFrom(catalogFile)
+        task.get().catalogClassNames.put("another.toml", "AnotherVersions")
+
+        val exception = assertThrows<GradleException> {
+            task.get().executeTask()
+        }
+
+        assertTrue(exception.message!!.contains("not in tomlFiles"))
+        assertTrue(exception.message!!.contains("another.toml"))
     }
 
     @Test

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
@@ -154,6 +154,80 @@ class PortableVersionCatalogGeneratorPluginTest {
     }
 
     @Test
+    fun `fail on class name collision and allow resolving it with explicit names`() {
+        val firstCatalog = projectDir.resolve("catalog/team-a/libs-main.toml")
+        val secondCatalog = projectDir.resolve("catalog/team-b/libs_main.toml")
+        firstCatalog.parentFile.mkdirs()
+        secondCatalog.parentFile.mkdirs()
+        writeMinimalTomlFile(firstCatalog)
+        writeMinimalTomlFile(secondCatalog)
+        writeBuildFile(tomlFiles = listOf(firstCatalog, secondCatalog))
+
+        val failedResult = runner("generatePortableVersionCatalog").buildAndFail()
+
+        assertTrue(failedResult.output.contains("Multiple version catalogs"))
+        assertTrue(failedResult.output.contains(firstCatalog.absolutePath))
+        assertTrue(failedResult.output.contains(secondCatalog.absolutePath))
+        assertTrue(failedResult.output.contains("catalogClassNames"))
+
+        writeBuildFile(
+            tomlFiles = listOf(firstCatalog, secondCatalog),
+            catalogClassNames = mapOf(
+                "catalog/team-a/libs-main.toml" to "TeamAVersions",
+                "catalog/team-b/libs_main.toml" to "TeamBVersions"
+            )
+        )
+
+        val successfulResult = runner(
+            "compileKotlin",
+            "--configuration-cache",
+            "--configuration-cache-problems=fail"
+        ).build()
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            successfulResult.task(":generatePortableVersionCatalog")?.outcome
+        )
+
+        val generatedPackage = projectDir.resolve("build/generated/sources/com/example/catalog")
+        assertTrue(
+            generatedPackage.resolve("TeamAVersionsCatalog.kt")
+                .readText()
+                .contains("class TeamAVersions private constructor()")
+        )
+        assertTrue(
+            generatedPackage.resolve("TeamBVersionsCatalog.kt")
+                .readText()
+                .contains("class TeamBVersions private constructor()")
+        )
+        assertTrue(
+            projectDir.resolve(
+                "build/classes/kotlin/main/com/example/catalog/TeamAVersions.class"
+            ).exists()
+        )
+        assertTrue(
+            projectDir.resolve(
+                "build/classes/kotlin/main/com/example/catalog/TeamBVersions.class"
+            ).exists()
+        )
+
+        writeBuildFile(
+            tomlFiles = listOf(firstCatalog, secondCatalog),
+            catalogClassNames = mapOf(
+                "catalog/team-a/libs-main.toml" to "RenamedTeamAVersions",
+                "catalog/team-b/libs_main.toml" to "TeamBVersions"
+            )
+        )
+        runner(
+            "generatePortableVersionCatalog",
+            "--configuration-cache",
+            "--configuration-cache-problems=fail"
+        ).build()
+
+        assertFalse(generatedPackage.resolve("TeamAVersionsCatalog.kt").exists())
+        assertTrue(generatedPackage.resolve("RenamedTeamAVersionsCatalog.kt").exists())
+    }
+
+    @Test
     fun `remove stale generated sources when catalogs change`() {
         val firstCatalog = projectDir.resolve("first.toml")
         val secondCatalog = projectDir.resolve("second.toml")
@@ -215,7 +289,8 @@ class PortableVersionCatalogGeneratorPluginTest {
 
     private fun writeBuildFile(
         projectVersion: String = "1.2.3",
-        tomlFiles: List<File>? = listOf(projectDir.resolve(versionsFileName))
+        tomlFiles: List<File>? = listOf(projectDir.resolve(versionsFileName)),
+        catalogClassNames: Map<String, String> = emptyMap()
     ) {
         val tomlFilesConfiguration = when {
             tomlFiles == null -> ""
@@ -225,6 +300,10 @@ class PortableVersionCatalogGeneratorPluginTest {
                 postfix = "))"
             ) { "\"${it.absolutePath}\"" }
         }
+        val catalogClassNamesConfiguration = catalogClassNames.entries
+            .joinToString("\n") { (catalogPath, className) ->
+                """catalogClassNames.put("$catalogPath", "$className")"""
+            }
         val buildFile = projectDir.resolve("build.gradle.kts")
         buildFile.writeText(
             """
@@ -241,6 +320,7 @@ class PortableVersionCatalogGeneratorPluginTest {
             portableVersionCatalog {
                 catalogPackage.set("com.example.catalog")
                 $tomlFilesConfiguration
+                $catalogClassNamesConfiguration
                 outputDir.set(file("build/generated/sources"))
             }
 


### PR DESCRIPTION
## Summary
- add `catalogClassNames` for assigning exact generated Kotlin class names per TOML catalog
- reject conflicting generated names with an actionable error that suggests renaming files or configuring explicit names
- validate configured paths and Kotlin/Java-compatible class names
- remove stale generated sources when an explicit class name changes
- document the new DSL and cover it with unit and Gradle TestKit tests

## Verification
- `./gradlew clean check`
- `./gradlew check`