### PR TITLE
Preserve rich versions in generated Gradle types

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,34 @@ dependencies {
 }
 ```
 
+The generated public API uses Gradle types rather than PoVerCat-specific DTOs:
+
+| Catalog section | Generated type |
+| --- | --- |
+| `versions` | `VersionConstraint` |
+| `libraries` | `MinimalExternalModuleDependency` |
+| `bundles` | `Provider<ExternalModuleDependencyBundle>` |
+| `plugins` | `PluginDependency` |
+
+This means library and bundle accessors can be passed to Gradle dependency
+configurations. Bundle accessors accept an `ObjectFactory`; Gradle uses it to
+create a typed provider with the same dependency-notation behavior as a standard
+version-catalog bundle:
+
+```kotlin
+dependencies {
+    implementation(LibsVersions.Libraries.jacocoTool)
+    implementation(LibsVersions.Bundles.testing(objects))
+}
+```
+
+PoVerCat keeps the parsed catalog definition private and converts it to the Gradle
+types above. Rich versions retain `require`, `strictly`, `prefer`, `reject`, and
+`rejectAll` data. Conversion follows Gradle's native `MutableVersionConstraint`
+semantics: when both `require` and `strictly` are present, applying `strictly`
+makes the strict value the exposed required version; the preferred and rejected
+versions remain available through the same constraint.
+
 Once the dependency is in place, Kotlin consumers can use the version values directly:
 
 ```kotlin

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogClassGenerator.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogClassGenerator.kt
@@ -64,6 +64,8 @@ class PortableVersionCatalogClassGenerator {
 
                     generatePluginsPart(this, plugins, parsedVersions)
 
+                    appendLine()
+                    appendGradleTypeAdapters(this)
                     appendLine("}")
                 }
             } catch (e: Exception) {
@@ -90,17 +92,10 @@ class PortableVersionCatalogClassGenerator {
 
                             appendLine()
                             appendLine("        @JvmStatic")
-                            appendLine("        val ${TomlParserUtils.toCamelCase(key)}: VersionConstraint = DefaultImmutableVersionConstraint(")
-                            appendLine("            \"${parsedVersion.preferredVersion}\",")
-                            appendLine("            \"${parsedVersion.requiredVersion}\",")
-                            appendLine("            \"${parsedVersion.strictVersion}\",")
-                            if (parsedVersion.rejectedVersions.isNotEmpty()) {
-                                appendLine("            listOf(${parsedVersion.rejectedVersions.joinToString(", ") { "\"${it}\"" }}),")
-                            } else {
-                                appendLine("            emptyList<String>(),")
-                            }
-                            appendLine("            null")
-                            appendLine("        )")
+                            appendLine(
+                                "        val ${TomlParserUtils.toCamelCase(key)}: VersionConstraint = " +
+                                        "CatalogGradleTypeFactory.version(${parsedVersion.render()})"
+                            )
                         }
                     }
 
@@ -124,29 +119,21 @@ class PortableVersionCatalogClassGenerator {
                         val parsedLibrary = TomlParserUtils.parseLibrary(value, parsedVersions)
 
                         if (parsedLibrary.isNotEmpty()) {
+                            val libraryName = TomlParserUtils.toCamelCase(key)
+
                             appendLine()
                             appendLine("        @JvmStatic")
-                            appendLine("        val ${TomlParserUtils.toCamelCase(key)}: MinimalExternalModuleDependency = DefaultMinimalDependency(")
-                            appendLine("            DefaultModuleIdentifier.newId(\"${parsedLibrary.group}\", \"${parsedLibrary.name}\"),")
-                            appendLine("            DefaultMutableVersionConstraint(")
-                            appendLine("                DefaultImmutableVersionConstraint(")
-                            appendLine("                    \"${parsedLibrary.version.preferredVersion}\",")
-                            appendLine("                    \"${parsedLibrary.version.requiredVersion}\",")
-                            appendLine("                    \"${parsedLibrary.version.strictVersion}\",")
-                            if (parsedLibrary.version.rejectedVersions.isNotEmpty()) {
-                                appendLine(
-                                    "                    listOf(${
-                                        parsedLibrary.version.rejectedVersions.joinToString(
-                                            ", "
-                                        ) { "\"${it}\"" }
-                                    }),"
-                                )
-                            } else {
-                                appendLine("                    emptyList<String>(),")
-                            }
-                            appendLine("                    null")
-                            appendLine("                )")
-                            appendLine("            )")
+                            appendLine(
+                                "        val $libraryName: MinimalExternalModuleDependency = " +
+                                        "CatalogGradleTypeFactory.library("
+                            )
+                            appendLine(
+                                "            CatalogLibrary(" +
+                                        "\"${parsedLibrary.group}\", " +
+                                        "\"${parsedLibrary.name}\", " +
+                                        "${parsedLibrary.version.render()}" +
+                                        ")"
+                            )
                             appendLine("        )")
                         }
                     }
@@ -162,33 +149,36 @@ class PortableVersionCatalogClassGenerator {
                 with(stringBuilder) {
                     appendLine("    object Bundles {")
 
-                    val parsedBundles = java.util.HashMap<String, List<String>>()
-
                     bundles.forEach { (key, value) ->
                         val bundleLibraries = TomlParserUtils.parseBundle(value)
 
                         if (bundleLibraries.isNotEmpty()) {
                             val bundleName = TomlParserUtils.toCamelCase(key)
-                            parsedBundles.put(bundleName, bundleLibraries)
 
                             appendLine()
                             appendLine("        @JvmStatic")
-                            appendLine("        val $bundleName: ExternalModuleDependencyBundle = DefaultExternalModuleDependencyBundle()")
+                            appendLine(
+                                "        fun $bundleName(objectFactory: ObjectFactory): " +
+                                        "Provider<ExternalModuleDependencyBundle> ="
+                            )
+                            appendLine(
+                                "            objectFactory.property(" +
+                                        "ExternalModuleDependencyBundle::class.java" +
+                                        ").apply {"
+                            )
+                            appendLine("                set(")
+                            appendLine("                    CatalogGradleTypeFactory.bundle(")
+                            appendLine("                        listOf(")
+                            appendLine(
+                                bundleLibraries.joinToString(",\n") {
+                                    "                            Libraries.$it"
+                                }
+                            )
+                            appendLine("                        )")
+                            appendLine("                    )")
+                            appendLine("                )")
+                            appendLine("            }")
                         }
-                    }
-
-                    if (parsedBundles.isNotEmpty()) {
-                        appendLine()
-                        appendLine("        init {")
-
-                        appendLine(
-                            parsedBundles.map { (key, value) ->
-                                value.joinToString("\n") { "            $key.add(Libraries.$it)" }
-                            }
-                                .joinToString("\n\n")
-                        )
-
-                        appendLine("        }")
                     }
 
                     appendLine("    }")
@@ -212,22 +202,12 @@ class PortableVersionCatalogClassGenerator {
                         if (plugin.isNotEmpty()) {
                             appendLine()
                             appendLine("        @JvmStatic")
-                            appendLine("        val ${TomlParserUtils.toCamelCase(key)}: PluginDependency = DefaultPluginDependency(")
-                            appendLine("            \"${plugin.id}\",")
-                            appendLine("            DefaultMutableVersionConstraint(")
-                            appendLine("                DefaultImmutableVersionConstraint(")
-                            appendLine("                    \"${plugin.version.preferredVersion}\",")
-                            appendLine("                    \"${plugin.version.requiredVersion}\",")
-                            appendLine("                    \"${plugin.version.strictVersion}\",")
-                            if (plugin.version.rejectedVersions.isNotEmpty()) {
-                                appendLine("                    listOf(${plugin.version.rejectedVersions.joinToString(", ") { "\"${it}\"" }}),")
-                            } else {
-                                appendLine("                    emptyList<String>(),")
-                            }
-                            appendLine("                    null")
-                            appendLine("                )")
-                            appendLine("            )")
-                            appendLine("        )")
+                            appendLine(
+                                "        val ${TomlParserUtils.toCamelCase(key)}: PluginDependency = " +
+                                        "CatalogGradleTypeFactory.plugin(" +
+                                        "\"${plugin.id}\", ${plugin.version.render()}" +
+                                        ")"
+                            )
                         }
                     }
 
@@ -235,6 +215,88 @@ class PortableVersionCatalogClassGenerator {
                 }
             }
         }
+
+        private fun appendGradleTypeAdapters(stringBuilder: StringBuilder) {
+            with(stringBuilder) {
+                appendLine("    private data class CatalogVersion(")
+                appendLine("        val requiredVersion: String,")
+                appendLine("        val strictVersion: String,")
+                appendLine("        val preferredVersion: String,")
+                appendLine("        val rejectedVersions: List<String>")
+                appendLine("    )")
+                appendLine()
+                appendLine("    private data class CatalogLibrary(")
+                appendLine("        val group: String,")
+                appendLine("        val name: String,")
+                appendLine("        val version: CatalogVersion")
+                appendLine("    )")
+                appendLine()
+                appendLine("    private object CatalogGradleTypeFactory {")
+                appendLine("        fun version(version: CatalogVersion): VersionConstraint =")
+                appendLine("            mutableVersion(version).asImmutable()")
+                appendLine()
+                appendLine(
+                    "        fun library(library: CatalogLibrary): " +
+                            "MinimalExternalModuleDependency ="
+                )
+                appendLine("            DefaultMinimalDependency(")
+                appendLine("                DefaultModuleIdentifier.newId(library.group, library.name),")
+                appendLine("                mutableVersion(library.version)")
+                appendLine("            )")
+                appendLine()
+                appendLine(
+                    "        fun bundle(dependencies: List<MinimalExternalModuleDependency>): " +
+                            "ExternalModuleDependencyBundle ="
+                )
+                appendLine("            DefaultExternalModuleDependencyBundle().apply {")
+                appendLine("                addAll(dependencies)")
+                appendLine("            }")
+                appendLine()
+                appendLine(
+                    "        fun plugin(id: String, version: CatalogVersion): PluginDependency ="
+                )
+                appendLine("            DefaultPluginDependency(id, mutableVersion(version))")
+                appendLine()
+                appendLine(
+                    "        private fun mutableVersion(version: CatalogVersion): " +
+                            "DefaultMutableVersionConstraint ="
+                )
+                appendLine("            DefaultMutableVersionConstraint(\"\").apply {")
+                appendLine("                if (version.requiredVersion.isNotBlank()) {")
+                appendLine("                    require(version.requiredVersion)")
+                appendLine("                }")
+                appendLine("                if (version.strictVersion.isNotBlank()) {")
+                appendLine("                    strictly(version.strictVersion)")
+                appendLine("                }")
+                appendLine("                if (version.preferredVersion.isNotBlank()) {")
+                appendLine("                    prefer(version.preferredVersion)")
+                appendLine("                }")
+                appendLine("                when {")
+                appendLine("                    version.rejectedVersions == listOf(\"+\") -> rejectAll()")
+                appendLine(
+                    "                    version.rejectedVersions.isNotEmpty() -> " +
+                            "reject(*version.rejectedVersions.toTypedArray())"
+                )
+                appendLine("                }")
+                appendLine("            }")
+                appendLine("    }")
+            }
+        }
+
+        private fun TomlParserUtils.TomlVersion.render(): String =
+            "CatalogVersion(" +
+                    "requiredVersion = \"$requiredVersion\", " +
+                    "strictVersion = \"$strictVersion\", " +
+                    "preferredVersion = \"$preferredVersion\", " +
+                    "rejectedVersions = ${rejectedVersions.renderStringList()}" +
+                    ")"
+
+        private fun List<String>.renderStringList(): String =
+            if (isEmpty()) {
+                "emptyList()"
+            } else {
+                joinToString(prefix = "listOf(", postfix = ")") { "\"$it\"" }
+            }
 
         private fun appendCopyright(stringBuilder: StringBuilder) {
             with(stringBuilder) {
@@ -261,11 +323,12 @@ class PortableVersionCatalogClassGenerator {
                 appendLine("import org.gradle.api.artifacts.MinimalExternalModuleDependency")
                 appendLine("import org.gradle.api.artifacts.VersionConstraint")
                 appendLine("import org.gradle.api.internal.artifacts.DefaultModuleIdentifier")
-                appendLine("import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint")
                 appendLine("import org.gradle.api.internal.artifacts.dependencies.DefaultMinimalDependency")
                 appendLine("import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint")
                 appendLine("import org.gradle.api.internal.artifacts.dependencies.DefaultPluginDependency")
                 appendLine("import org.gradle.api.internal.catalog.DefaultExternalModuleDependencyBundle")
+                appendLine("import org.gradle.api.model.ObjectFactory")
+                appendLine("import org.gradle.api.provider.Provider")
                 appendLine("import org.gradle.plugin.use.PluginDependency")
             }
         }

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
@@ -99,6 +99,48 @@ class PortableVersionCatalogGeneratorPluginTest {
     }
 
     @Test
+    fun `generated catalog exposes public Gradle types and preserves rich versions`() {
+        writeBuildFile()
+        writeTomlFile()
+
+        val producerResult = runner("jar").build()
+        assertEquals(TaskOutcome.SUCCESS, producerResult.task(":jar")?.outcome)
+
+        val generatedCatalog = projectDir.resolve(
+            "build/generated/sources/com/example/catalog/VersionsCatalog.kt"
+        ).readText()
+        assertTrue(
+            generatedCatalog.contains(
+                "val libWithVersionAsObject: MinimalExternalModuleDependency"
+            )
+        )
+        assertTrue(
+            generatedCatalog.contains(
+                "fun testBundleSimple(objectFactory: ObjectFactory): " +
+                    "Provider<ExternalModuleDependencyBundle>"
+            )
+        )
+        assertTrue(generatedCatalog.contains("val pluginVersionAsObject: PluginDependency"))
+        assertTrue(generatedCatalog.contains("val versionAsObject: VersionConstraint"))
+
+        val producerJar = projectDir.resolve("build/libs")
+            .listFiles { file -> file.extension == "jar" }
+            ?.single()
+            ?: error("Expected exactly one producer JAR")
+        val consumerDir = projectDir.resolve("consumer").apply { mkdirs() }
+        writeConsumerBuild(consumerDir, producerJar)
+        writeJavaConsumer(consumerDir)
+
+        val consumerResult = GradleRunner.create()
+            .withProjectDir(consumerDir)
+            .withArguments("compileJava", "verifyCatalog")
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, consumerResult.task(":compileJava")?.outcome)
+        assertEquals(TaskOutcome.SUCCESS, consumerResult.task(":verifyCatalog")?.outcome)
+    }
+
+    @Test
     fun `fail with clear message when producer has no supported Kotlin plugin`() {
         projectDir.resolve("build.gradle.kts").writeText(
             """
@@ -365,6 +407,122 @@ class PortableVersionCatalogGeneratorPluginTest {
             plugin-version-ref = { id = "com.test.plugin-version-ref", version.ref = "version-simple" }
             plugin-version-as-object = { id = "com.test.version-as-object", version = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] } }
             plugin-simple-id.id = "com.text.plugin-with-id"
+            """.trimIndent()
+        )
+    }
+
+    private fun writeConsumerBuild(consumerDir: File, producerJar: File) {
+        consumerDir.resolve("settings.gradle.kts").writeText(
+            """rootProject.name = "catalog-consumer""""
+        )
+        consumerDir.resolve("build.gradle.kts").writeText(
+            """
+            import com.example.catalog.Versions
+            import org.gradle.api.artifacts.ExternalModuleDependencyBundle
+            import org.gradle.api.artifacts.MinimalExternalModuleDependency
+            import org.gradle.api.artifacts.VersionConstraint
+            import org.gradle.api.provider.Provider
+            import org.gradle.plugin.use.PluginDependency
+
+            buildscript {
+                dependencies {
+                    classpath(files("${producerJar.invariantSeparatorsPath}"))
+                }
+            }
+
+            plugins {
+                java
+            }
+
+            dependencies {
+                implementation(gradleApi())
+                implementation(files("${producerJar.invariantSeparatorsPath}"))
+            }
+
+            val richVersion: VersionConstraint = Versions.Versions.versionAsObject
+            val richLibrary: MinimalExternalModuleDependency =
+                Versions.Libraries.libWithVersionAsObject
+            val richPlugin: PluginDependency = Versions.Plugins.pluginVersionAsObject
+            val bundle: Provider<ExternalModuleDependencyBundle> =
+                Versions.Bundles.testBundleSimple(objects)
+
+            val catalogVerification = configurations.create("catalogVerification") {
+                isCanBeResolved = false
+                isCanBeConsumed = false
+            }
+            dependencies.add(catalogVerification.name, richLibrary)
+            dependencies.addProvider(catalogVerification.name, bundle)
+
+            tasks.register("verifyCatalog") {
+                doLast {
+                    check(richVersion.requiredVersion == "1.1.1")
+                    check(richVersion.strictVersion == "1.1.1")
+                    check(richVersion.preferredVersion == "1.0.0")
+                    check(richVersion.rejectedVersions == listOf("0.0.1", "0.0.2"))
+                    check(Versions.Versions.versionSimple.requiredVersion == "1.2.3")
+                    check(Versions.Versions.versionRejectAll.rejectedVersions == listOf("+"))
+
+                    check(richLibrary.group == "lib.test.version.as.object")
+                    check(richLibrary.name == "version-as-object")
+                    check(richLibrary.versionConstraint.requiredVersion == "1.1.1")
+                    check(richLibrary.versionConstraint.strictVersion == "1.1.1")
+                    check(richLibrary.versionConstraint.preferredVersion == "1.0.0")
+                    check(
+                        richLibrary.versionConstraint.rejectedVersions ==
+                            listOf("0.0.1", "0.0.2")
+                    )
+                    check(
+                        Versions.Libraries.libWithVersionRef
+                            .versionConstraint
+                            .requiredVersion == "1.2.3"
+                    )
+
+                    check(richPlugin.pluginId == "com.test.version-as-object")
+                    check(richPlugin.version.requiredVersion == "1.1.1")
+                    check(richPlugin.version.strictVersion == "1.1.1")
+                    check(richPlugin.version.preferredVersion == "1.0.0")
+                    check(richPlugin.version.rejectedVersions == listOf("0.0.1", "0.0.2"))
+                    check(Versions.Plugins.pluginVersionRef.version.requiredVersion == "1.2.3")
+
+                    check(bundle.get().size == 2)
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
+    private fun writeJavaConsumer(consumerDir: File) {
+        val javaSource = consumerDir.resolve("src/main/java/JavaCatalogUsage.java")
+        javaSource.parentFile.mkdirs()
+        javaSource.writeText(
+            """
+            import com.example.catalog.Versions;
+            import org.gradle.api.artifacts.ExternalModuleDependencyBundle;
+            import org.gradle.api.artifacts.MinimalExternalModuleDependency;
+            import org.gradle.api.artifacts.VersionConstraint;
+            import org.gradle.api.model.ObjectFactory;
+            import org.gradle.api.provider.Provider;
+            import org.gradle.plugin.use.PluginDependency;
+
+            public final class JavaCatalogUsage {
+                public static VersionConstraint version() {
+                    return Versions.Versions.getVersionAsObject();
+                }
+
+                public static MinimalExternalModuleDependency library() {
+                    return Versions.Libraries.getLibWithVersionAsObject();
+                }
+
+                public static Provider<ExternalModuleDependencyBundle> bundle(
+                    ObjectFactory objectFactory
+                ) {
+                    return Versions.Bundles.testBundleSimple(objectFactory);
+                }
+
+                public static PluginDependency plugin() {
+                    return Versions.Plugins.getPluginVersionAsObject();
+                }
+            }
             """.trimIndent()
         )
     }


### PR DESCRIPTION
## Summary
- expose Gradle-native catalog interfaces from generated accessors
- centralize conversion of parsed rich versions into Gradle constraints
- make generated bundles usable as typed Gradle providers
- document the generated API and rich-version semantics

## Tests
- `./gradlew clean check`
- Kotlin DSL consumer verifies dependency and bundle notation
- Java consumer compiles against all generated public interfaces