### PR TITLE
Validate version catalog inputs before generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ to clean up. PoVerCat tracks the files it owns in
 classes when a configured catalog is removed or renamed. Do not edit this manifest
 manually.
 
+PoVerCat validates every configured catalog before generating source code. This is
+necessary because custom files from `tomlFiles` are not necessarily imported by
+Gradle as settings-level version catalogs and therefore may not be validated by
+Gradle itself. Generation fails with the catalog path, entry, and source position
+when PoVerCat finds invalid TOML, malformed library or version declarations,
+unknown `version.ref` values, or unknown library aliases in a bundle. Libraries
+and plugins without a version remain supported.
+
 The default package for the generated classes is `org.gradle.version.catalog`. This too can be customized via plugin configuration.
 
 By default, the generated source files are placed under `build/generated/sources`. You can also override this output directory if needed.

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogClassGenerator.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogClassGenerator.kt
@@ -37,6 +37,7 @@ class PortableVersionCatalogClassGenerator {
             try {
                 val tomlContent = file.readText()
                 val toml = Toml.parse(tomlContent)
+                VersionCatalogValidator.validate(file, toml)
 
                 val versions = toml.toMap("versions")
                 val libraries = toml.toMap("libraries")

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/VersionCatalogValidator.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/VersionCatalogValidator.kt
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.the13haven.gradle.povercat
+
+import org.gradle.api.GradleException
+import org.tomlj.TomlArray
+import org.tomlj.TomlParseResult
+import org.tomlj.TomlPosition
+import org.tomlj.TomlTable
+import java.io.File
+
+/**
+ * Validates the subset of the Gradle version-catalog format supported by PoVerCat.
+ */
+internal object VersionCatalogValidator {
+
+    private val versionKeys = setOf("require", "strictly", "prefer", "reject", "rejectAll")
+    private val libraryKeys = setOf("group", "name", "module", "version")
+    private val pluginKeys = setOf("id", "version")
+
+    fun validate(catalogFile: File, catalog: TomlParseResult) {
+        if (catalog.hasErrors()) {
+            val syntaxErrors = catalog.errors().joinToString(separator = "\n") { error ->
+                "${error.position().render()}: ${error.message}"
+            }
+            throw invalidCatalog(catalogFile, syntaxErrors)
+        }
+
+        val errors = mutableListOf<String>()
+        val versions = catalog.section("versions", errors)
+        val libraries = catalog.section("libraries", errors)
+        val plugins = catalog.section("plugins", errors)
+        val bundles = catalog.section("bundles", errors)
+
+        versions?.validateVersions(errors)
+        libraries?.validateLibraries(versions?.keySet().orEmpty(), errors)
+        plugins?.validatePlugins(versions?.keySet().orEmpty(), errors)
+        bundles?.validateBundles(libraries?.keySet().orEmpty(), errors)
+
+        if (errors.isNotEmpty()) {
+            throw invalidCatalog(
+                catalogFile,
+                errors.joinToString(separator = "\n") { error -> "- $error" }
+            )
+        }
+    }
+
+    private fun TomlParseResult.section(
+        sectionName: String,
+        errors: MutableList<String>
+    ): TomlTable? =
+        when (val section = get(sectionName)) {
+            null -> null
+            is TomlTable -> section
+            else -> {
+                errors += "[$sectionName] must be a TOML table."
+                null
+            }
+        }
+
+    private fun TomlTable.validateVersions(errors: MutableList<String>) {
+        forEachEntry("versions") { alias, value, location ->
+            when (value) {
+                is String -> {
+                    if (value.isBlank()) {
+                        errors += "$location must not contain an empty version."
+                    }
+                }
+
+                is TomlTable -> value.validateRichVersion(location, errors)
+                else -> errors += "$location must be a string or a rich-version table."
+            }
+        }
+    }
+
+    private fun TomlTable.validateLibraries(
+        versionAliases: Set<String>,
+        errors: MutableList<String>
+    ) {
+        forEachEntry("libraries") { _, value, location ->
+            when (value) {
+                is String -> validateLibraryNotation(value, location, expectedParts = 3, errors)
+                is TomlTable -> value.validateLibrary(location, versionAliases, errors)
+                else -> errors += "$location must be a string or a library table."
+            }
+        }
+    }
+
+    private fun TomlTable.validateLibrary(
+        location: String,
+        versionAliases: Set<String>,
+        errors: MutableList<String>
+    ) {
+        validateKnownKeys(libraryKeys, location, errors)
+
+        val module = get("module")
+        val group = get("group")
+        val name = get("name")
+
+        if (module != null) {
+            if (group != null || name != null) {
+                errors += "$location must use either 'module' or 'group'/'name', not both."
+            }
+            if (module is String) {
+                validateLibraryNotation(module, "$location.module", expectedParts = 2, errors)
+            } else {
+                errors += "$location.module must be a string in 'group:name' format."
+            }
+        } else {
+            validateRequiredString(group, "$location.group", errors)
+            validateRequiredString(name, "$location.name", errors)
+        }
+
+        validateVersionReference(get("version"), location, versionAliases, errors)
+    }
+
+    private fun TomlTable.validatePlugins(
+        versionAliases: Set<String>,
+        errors: MutableList<String>
+    ) {
+        forEachEntry("plugins") { _, value, location ->
+            if (value !is TomlTable) {
+                errors += "$location must be a plugin table."
+                return@forEachEntry
+            }
+
+            value.validateKnownKeys(pluginKeys, location, errors)
+            validateRequiredString(value.get("id"), "$location.id", errors)
+            validateVersionReference(value.get("version"), location, versionAliases, errors)
+        }
+    }
+
+    private fun TomlTable.validateBundles(
+        libraryAliases: Set<String>,
+        errors: MutableList<String>
+    ) {
+        forEachEntry("bundles") { _, value, location ->
+            if (value !is TomlArray) {
+                errors += "$location must be an array of library aliases."
+                return@forEachEntry
+            }
+
+            value.toList().forEachIndexed { index, libraryAlias ->
+                when {
+                    libraryAlias !is String ->
+                        errors += "$location[$index] must be a library alias string."
+
+                    libraryAlias !in libraryAliases ->
+                        errors += "$location references unknown library alias '$libraryAlias'."
+                }
+            }
+        }
+    }
+
+    private fun validateVersionReference(
+        versionValue: Any?,
+        ownerLocation: String,
+        versionAliases: Set<String>,
+        errors: MutableList<String>
+    ) {
+        when (versionValue) {
+            null -> Unit
+            is String -> {
+                if (versionValue.isBlank()) {
+                    errors += "$ownerLocation.version must not be empty."
+                }
+            }
+
+            is TomlTable -> {
+                val reference = versionValue.get("ref")
+                if (reference != null) {
+                    versionValue.validateKnownKeys(setOf("ref"), "$ownerLocation.version", errors)
+                    when {
+                        reference !is String || reference.isBlank() ->
+                            errors += "$ownerLocation.version.ref must be a non-empty string."
+
+                        reference !in versionAliases ->
+                            errors +=
+                                "$ownerLocation references unknown version alias '$reference'."
+                    }
+                } else {
+                    versionValue.validateRichVersion("$ownerLocation.version", errors)
+                }
+            }
+
+            else -> errors += "$ownerLocation.version must be a string or a version table."
+        }
+    }
+
+    private fun TomlTable.validateRichVersion(
+        location: String,
+        errors: MutableList<String>
+    ) {
+        validateKnownKeys(versionKeys, location, errors)
+
+        listOf("require", "strictly", "prefer").forEach { key ->
+            val value: Any? = get(key)
+            if (value != null) {
+                if (value !is String || value.isBlank()) {
+                    errors += "$location.$key must be a non-empty string."
+                }
+            }
+        }
+
+        val rejectedVersions: Any? = get("reject")
+        if (rejectedVersions != null) {
+            when {
+                rejectedVersions !is TomlArray ->
+                    errors += "$location.reject must be an array of version strings."
+
+                rejectedVersions.toList().any { it !is String || it.isBlank() } ->
+                    errors += "$location.reject must contain only non-empty version strings."
+            }
+        }
+
+        val rejectAll: Any? = get("rejectAll")
+        if (rejectAll != null) {
+            if (rejectAll !is Boolean) {
+                errors += "$location.rejectAll must be a boolean."
+            }
+        }
+
+        if (keySet().isEmpty()) {
+            errors += "$location must define at least one version constraint."
+        }
+    }
+
+    private fun TomlTable.validateKnownKeys(
+        supportedKeys: Set<String>,
+        location: String,
+        errors: MutableList<String>
+    ) {
+        (keySet() - supportedKeys).sorted().forEach { unknownKey ->
+            errors += "$location contains unsupported key '$unknownKey'."
+        }
+    }
+
+    private fun validateLibraryNotation(
+        notation: String,
+        location: String,
+        expectedParts: Int,
+        errors: MutableList<String>
+    ) {
+        val parts = notation.split(':')
+        if (parts.size != expectedParts || parts.any(String::isBlank)) {
+            val format = if (expectedParts == 2) "group:name" else "group:name:version"
+            errors += "$location must use non-empty '$format' notation."
+        }
+    }
+
+    private fun validateRequiredString(
+        value: Any?,
+        location: String,
+        errors: MutableList<String>
+    ) {
+        if (value !is String || value.isBlank()) {
+            errors += "$location must be a non-empty string."
+        }
+    }
+
+    private inline fun TomlTable.forEachEntry(
+        sectionName: String,
+        action: (alias: String, value: Any, location: String) -> Unit
+    ) {
+        entrySet().forEach { (alias, value) ->
+            val position = inputPositionOf(alias)
+            action(alias, value, "[$sectionName].$alias (${position.render()})")
+        }
+    }
+
+    private fun TomlPosition?.render(): String =
+        if (this == null) {
+            "unknown position"
+        } else {
+            "line ${line()}, column ${column()}"
+        }
+
+    private fun invalidCatalog(catalogFile: File, details: String): GradleException =
+        GradleException(
+            "Invalid version catalog '${catalogFile.absolutePath}':\n$details"
+        )
+}

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
@@ -196,6 +196,24 @@ class PortableVersionCatalogGeneratorPluginTest {
     }
 
     @Test
+    fun `fail fast when catalog contains an unknown version reference`() {
+        writeBuildFile()
+        projectDir.resolve(versionsFileName).writeText(
+            """
+            [libraries]
+            invalid-library = { module = "com.example:invalid", version.ref = "missing" }
+            """.trimIndent()
+        )
+
+        val result = runner("generatePortableVersionCatalog").buildAndFail()
+
+        assertTrue(result.output.contains("Invalid version catalog"))
+        assertTrue(result.output.contains(projectDir.resolve(versionsFileName).absolutePath))
+        assertTrue(result.output.contains("[libraries].invalid-library"))
+        assertTrue(result.output.contains("references unknown version alias 'missing'"))
+    }
+
+    @Test
     fun `fail on class name collision and allow resolving it with explicit names`() {
         val firstCatalog = projectDir.resolve("catalog/team-a/libs-main.toml")
         val secondCatalog = projectDir.resolve("catalog/team-b/libs_main.toml")
@@ -393,12 +411,11 @@ class PortableVersionCatalogGeneratorPluginTest {
             lib-simple-no-version.module = "com.mycompany:mylib"
             lib-module = { module = "com.mycompany:other", version = "1.4" }
             lib-with-version-ref = { group = "lib.test.version.ref", name = "version-ref", version.ref = "version-simple" }
-            lib-with-version-ref-not-found = { group = "lib.test.version.ref", name = "version-ref", version.ref = "version-unknown" }
             lib-with-version-as-object = { group = "lib.test.version.as.object", name = "version-as-object", version = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] } }
 
             [bundles]
 
-            test-bundle = ["lib-module", "lib-with-version-ref", "lib-with-version-ref-not-found"]
+            test-bundle = ["lib-module", "lib-with-version-ref"]
             test-bundle-simple = ["lib-simple-with-version", "lib-with-version-as-object"]
 
             [plugins]

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/VersionCatalogValidatorTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/VersionCatalogValidatorTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.the13haven.gradle.povercat
+
+import org.gradle.api.GradleException
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import org.tomlj.Toml
+import java.io.File
+
+class VersionCatalogValidatorTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `rejects invalid TOML syntax with file and position`() {
+        val catalog = catalogFile(
+            """
+            [versions
+            kotlin = "2.3.0"
+            """
+        )
+
+        val exception = validateAndCapture(catalog)
+
+        assertTrue(exception.message!!.contains(catalog.absolutePath))
+        assertTrue(exception.message!!.contains("line 1, column"))
+    }
+
+    @Test
+    fun `rejects unknown version references in libraries and plugins`() {
+        val catalog = catalogFile(
+            """
+            [versions]
+            kotlin = "2.3.0"
+
+            [libraries]
+            kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "missing-library-version" }
+
+            [plugins]
+            kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "missing-plugin-version" }
+            """
+        )
+
+        val exception = validateAndCapture(catalog)
+
+        assertTrue(exception.message!!.contains("[libraries].kotlin-reflect"))
+        assertTrue(
+            exception.message!!.contains(
+                "references unknown version alias 'missing-library-version'"
+            )
+        )
+        assertTrue(exception.message!!.contains("[plugins].kotlin-jvm"))
+        assertTrue(
+            exception.message!!.contains(
+                "references unknown version alias 'missing-plugin-version'"
+            )
+        )
+    }
+
+    @Test
+    fun `rejects unknown library references in bundles`() {
+        val catalog = catalogFile(
+            """
+            [libraries]
+            kotlin-reflect = "org.jetbrains.kotlin:kotlin-reflect:2.3.0"
+
+            [bundles]
+            kotlin = ["kotlin-reflect", "missing-library"]
+            """
+        )
+
+        val exception = validateAndCapture(catalog)
+
+        assertTrue(exception.message!!.contains("[bundles].kotlin"))
+        assertTrue(
+            exception.message!!.contains(
+                "references unknown library alias 'missing-library'"
+            )
+        )
+    }
+
+    @Test
+    fun `rejects malformed library declarations with actionable messages`() {
+        val catalog = catalogFile(
+            """
+            [libraries]
+            invalid-short-notation = "only-group"
+            invalid-module = { module = "group-only" }
+            incomplete-library = { group = "com.example" }
+            conflicting-library = { module = "com.example:module", group = "com.example", name = "module" }
+            """
+        )
+
+        val exception = validateAndCapture(catalog)
+
+        assertTrue(
+            exception.message!!.contains(
+                "[libraries].invalid-short-notation"
+            )
+        )
+        assertTrue(exception.message!!.contains("non-empty 'group:name:version' notation"))
+        assertTrue(exception.message!!.contains("[libraries].invalid-module"))
+        assertTrue(exception.message!!.contains("non-empty 'group:name' notation"))
+        assertTrue(exception.message!!.contains("[libraries].incomplete-library"))
+        assertTrue(exception.message!!.contains(".name must be a non-empty string"))
+        assertTrue(exception.message!!.contains("[libraries].conflicting-library"))
+        assertTrue(exception.message!!.contains("not both"))
+    }
+
+    @Test
+    fun `rejects unsupported and invalid rich-version fields`() {
+        val catalog = catalogFile(
+            """
+            [versions]
+            invalid = { requires = "1.0", reject = "1.1", rejectAll = "true" }
+            """
+        )
+
+        val exception = validateAndCapture(catalog)
+
+        assertTrue(exception.message!!.contains("unsupported key 'requires'"))
+        assertTrue(exception.message!!.contains(".reject must be an array"))
+        assertTrue(exception.message!!.contains(".rejectAll must be a boolean"))
+    }
+
+    @Test
+    fun `allows versionless libraries and plugins`() {
+        val catalog = catalogFile(
+            """
+            [libraries]
+            kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
+
+            [plugins]
+            java-library.id = "java-library"
+            """
+        )
+
+        VersionCatalogValidator.validate(catalog, Toml.parse(catalog.toPath()))
+    }
+
+    private fun catalogFile(content: String): File =
+        tempDir.resolve("libs.versions.toml").apply {
+            writeText(content.trimIndent())
+        }
+
+    private fun validateAndCapture(catalog: File): GradleException =
+        assertThrows {
+            VersionCatalogValidator.validate(catalog, Toml.parse(catalog.toPath()))
+        }
+}

--- a/plugin/src/test/resources/libs.versions.toml
+++ b/plugin/src/test/resources/libs.versions.toml
@@ -10,13 +10,12 @@ lib-simple-with-version = "com.mycompany:mylib:1.4"
 lib-simple-no-version.module = "com.mycompany:mylib"
 lib-module = { module = "com.mycompany:other", version = "1.4" }
 lib-with-version-ref = { group = "lib.test.version.ref", name = "version-ref", version.ref = "version-simple" }
-lib-with-version-ref-not-found = { group = "lib.test.version.ref", name = "version-ref", version.ref = "version-unknown" }
 lib-with-version-as-object = { group = "lib.test.version.as.object", name = "version-as-object", version = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] } }
 
 
 [bundles]
 
-test-bundle = ["lib-module", "lib-with-version-ref", "lib-with-version-ref-not-found"]
+test-bundle = ["lib-module", "lib-with-version-ref"]
 test-bundle-simple = ["lib-simple-with-version", "lib-with-version-as-object"]
 
 [plugins]


### PR DESCRIPTION
## Summary
- fail fast on TOML syntax errors with file, line, and column details
- validate supported library, plugin, rich-version, and bundle declarations before generation
- reject unknown `version.ref` and bundle library aliases instead of silently generating incomplete catalogs
- keep versionless libraries and plugins supported
- document why PoVerCat validates custom `tomlFiles` independently of Gradle settings catalogs

## Tests
- added focused validator tests for syntax, references, coordinates, rich versions, and versionless entries
- added a Gradle TestKit failure-path regression test
- `./gradlew clean check` (34 tests)