### PR TITLE
Escape values embedded in generated Kotlin

### DIFF
--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/KotlinSourceEscaping.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/KotlinSourceEscaping.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.the13haven.gradle.povercat
+
+/**
+ * Escapes external values before embedding them in generated Kotlin source.
+ */
+internal object KotlinSourceEscaping {
+
+    fun stringLiteral(value: String): String =
+        buildString(value.length + 2) {
+            append('"')
+            value.forEach { character ->
+                when (character) {
+                    '\\' -> append("\\\\")
+                    '"' -> append("\\\"")
+                    '$' -> append("\\$")
+                    '\b' -> append("\\b")
+                    '\t' -> append("\\t")
+                    '\n' -> append("\\n")
+                    '\r' -> append("\\r")
+                    else -> {
+                        if (character.requiresUnicodeEscape()) {
+                            append("\\u")
+                            append(character.code.toString(16).padStart(4, '0'))
+                        } else {
+                            append(character)
+                        }
+                    }
+                }
+            }
+            append('"')
+        }
+
+    fun kDocText(value: String): String =
+        value
+            .replace("*/", "*&#47;")
+            .map { character ->
+                if (
+                    character == '\n' ||
+                    character == '\r' ||
+                    character == '\u2028' ||
+                    character == '\u2029' ||
+                    character.requiresUnicodeEscape()
+                ) {
+                    ' '
+                } else {
+                    character
+                }
+            }
+            .joinToString(separator = "")
+
+    private fun Char.requiresUnicodeEscape(): Boolean =
+        code in 0x0000..0x001f ||
+                code in 0x007f..0x009f ||
+                this == '\u2028' ||
+                this == '\u2029'
+}

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogClassGenerator.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogClassGenerator.kt
@@ -130,8 +130,8 @@ class PortableVersionCatalogClassGenerator {
                             )
                             appendLine(
                                 "            CatalogLibrary(" +
-                                        "\"${parsedLibrary.group}\", " +
-                                        "\"${parsedLibrary.name}\", " +
+                                        "${KotlinSourceEscaping.stringLiteral(parsedLibrary.group)}, " +
+                                        "${KotlinSourceEscaping.stringLiteral(parsedLibrary.name)}, " +
                                         "${parsedLibrary.version.render()}" +
                                         ")"
                             )
@@ -206,7 +206,8 @@ class PortableVersionCatalogClassGenerator {
                             appendLine(
                                 "        val ${TomlParserUtils.toCamelCase(key)}: PluginDependency = " +
                                         "CatalogGradleTypeFactory.plugin(" +
-                                        "\"${plugin.id}\", ${plugin.version.render()}" +
+                                        "${KotlinSourceEscaping.stringLiteral(plugin.id)}, " +
+                                        "${plugin.version.render()}" +
                                         ")"
                             )
                         }
@@ -286,9 +287,9 @@ class PortableVersionCatalogClassGenerator {
 
         private fun TomlParserUtils.TomlVersion.render(): String =
             "CatalogVersion(" +
-                    "requiredVersion = \"$requiredVersion\", " +
-                    "strictVersion = \"$strictVersion\", " +
-                    "preferredVersion = \"$preferredVersion\", " +
+                    "requiredVersion = ${KotlinSourceEscaping.stringLiteral(requiredVersion)}, " +
+                    "strictVersion = ${KotlinSourceEscaping.stringLiteral(strictVersion)}, " +
+                    "preferredVersion = ${KotlinSourceEscaping.stringLiteral(preferredVersion)}, " +
                     "rejectedVersions = ${rejectedVersions.renderStringList()}" +
                     ")"
 
@@ -296,7 +297,9 @@ class PortableVersionCatalogClassGenerator {
             if (isEmpty()) {
                 "emptyList()"
             } else {
-                joinToString(prefix = "listOf(", postfix = ")") { "\"$it\"" }
+                joinToString(prefix = "listOf(", postfix = ")") {
+                    KotlinSourceEscaping.stringLiteral(it)
+                }
             }
 
         private fun appendCopyright(stringBuilder: StringBuilder) {
@@ -347,7 +350,9 @@ class PortableVersionCatalogClassGenerator {
                 appendLine(" * project and rebuild it.</p>")
                 appendLine(" *")
                 appendLine(" * @author PoVerCat plugin")
-                appendLine(" * @version v${projectVersion}")
+                appendLine(
+                    " * @version v${KotlinSourceEscaping.kDocText(projectVersion)}"
+                )
                 appendLine(" */")
             }
         }

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/KotlinSourceEscapingTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/KotlinSourceEscapingTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.the13haven.gradle.povercat
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class KotlinSourceEscapingTest {
+
+    @Test
+    fun `wraps plain text as a Kotlin string literal`() {
+        assertEquals(
+            "\"plain version 1.2.3\"",
+            KotlinSourceEscaping.stringLiteral("plain version 1.2.3")
+        )
+    }
+
+    @Test
+    fun `escapes Kotlin string syntax without changing its value`() {
+        val value = "quote\" backslash\\ dollar\$"
+
+        assertEquals(
+            "\"quote\\\" backslash\\\\ dollar\\${'$'}\"",
+            KotlinSourceEscaping.stringLiteral(value)
+        )
+    }
+
+    @Test
+    fun `escapes whitespace and control characters`() {
+        val value = "\b\t\n\r\u0000\u000c\u007f\u0085\u2028\u2029"
+
+        assertEquals(
+            "\"\\b\\t\\n\\r\\u0000\\u000c\\u007f\\u0085\\u2028\\u2029\"",
+            KotlinSourceEscaping.stringLiteral(value)
+        )
+    }
+
+    @Test
+    fun `preserves printable Unicode including supplementary characters`() {
+        assertEquals(
+            "\"Zażółć gęślą jaźń 😀\"",
+            KotlinSourceEscaping.stringLiteral("Zażółć gęślą jaźń 😀")
+        )
+    }
+
+    @Test
+    fun `prevents project version from breaking generated KDoc`() {
+        assertEquals(
+            "1.0*&#47; next  end tail",
+            KotlinSourceEscaping.kDocText("1.0*/\nnext\t\u0000end\u2028tail")
+        )
+    }
+}

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
@@ -404,6 +404,8 @@ class PortableVersionCatalogGeneratorPluginTest {
             version-simple = "1.2.3"
             version-as-object = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] }
             version-reject-all = { rejectAll = true }
+            version-escaped = 'required-${'$'}value-\path-"quoted"-end'
+            version-escaped-rich = { prefer = 'prefer-${'$'}value-\path-"quoted"-end', require = 'require-${'$'}value-\path-"quoted"-end', strictly = 'strict-${'$'}value-\path-"quoted"-end', reject = ['reject-${'$'}one-\path-"quoted"-end', 'reject-${'$'}two-\path-"quoted"-end'] }
 
             [libraries]
 
@@ -412,29 +414,42 @@ class PortableVersionCatalogGeneratorPluginTest {
             lib-module = { module = "com.mycompany:other", version = "1.4" }
             lib-with-version-ref = { group = "lib.test.version.ref", name = "version-ref", version.ref = "version-simple" }
             lib-with-version-as-object = { group = "lib.test.version.as.object", name = "version-as-object", version = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] } }
+            lib-escaped = { group = 'com.example.${'$'}group\path"quoted"-end', name = 'lib-${'$'}name\path"quoted"-end', version.ref = "version-escaped-rich" }
 
             [bundles]
 
             test-bundle = ["lib-module", "lib-with-version-ref"]
             test-bundle-simple = ["lib-simple-with-version", "lib-with-version-as-object"]
+            escaped-bundle = ["lib-escaped"]
 
             [plugins]
 
             plugin-simple-version = { id = "com.github.ben-manes.versions", version = "0.45.0" }
             plugin-version-ref = { id = "com.test.plugin-version-ref", version.ref = "version-simple" }
             plugin-version-as-object = { id = "com.test.version-as-object", version = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] } }
+            plugin-escaped = { id = 'com.example.${'$'}plugin\path"quoted"-end', version.ref = "version-escaped-rich" }
             plugin-simple-id.id = "com.text.plugin-with-id"
             """.trimIndent()
         )
     }
 
     private fun writeConsumerBuild(consumerDir: File, producerJar: File) {
+        val escapedRequired = "required-\$value-\\path-\"quoted\"-end".toBase64()
+        val escapedStrict = "strict-\$value-\\path-\"quoted\"-end".toBase64()
+        val escapedPreferred = "prefer-\$value-\\path-\"quoted\"-end".toBase64()
+        val escapedRejectedOne = "reject-\$one-\\path-\"quoted\"-end".toBase64()
+        val escapedRejectedTwo = "reject-\$two-\\path-\"quoted\"-end".toBase64()
+        val escapedGroup = "com.example.\$group\\path\"quoted\"-end".toBase64()
+        val escapedName = "lib-\$name\\path\"quoted\"-end".toBase64()
+        val escapedPluginId = "com.example.\$plugin\\path\"quoted\"-end".toBase64()
+
         consumerDir.resolve("settings.gradle.kts").writeText(
             """rootProject.name = "catalog-consumer""""
         )
         consumerDir.resolve("build.gradle.kts").writeText(
             """
             import com.example.catalog.Versions
+            import java.util.Base64
             import org.gradle.api.artifacts.ExternalModuleDependencyBundle
             import org.gradle.api.artifacts.MinimalExternalModuleDependency
             import org.gradle.api.artifacts.VersionConstraint
@@ -462,6 +477,22 @@ class PortableVersionCatalogGeneratorPluginTest {
             val richPlugin: PluginDependency = Versions.Plugins.pluginVersionAsObject
             val bundle: Provider<ExternalModuleDependencyBundle> =
                 Versions.Bundles.testBundleSimple(objects)
+            val escapedBundle: Provider<ExternalModuleDependencyBundle> =
+                Versions.Bundles.escapedBundle(objects)
+
+            fun decode(value: String): String =
+                String(Base64.getDecoder().decode(value), Charsets.UTF_8)
+
+            val escapedRequired = decode("$escapedRequired")
+            val escapedStrict = decode("$escapedStrict")
+            val escapedPreferred = decode("$escapedPreferred")
+            val escapedRejected = listOf(
+                decode("$escapedRejectedOne"),
+                decode("$escapedRejectedTwo")
+            )
+            val escapedGroup = decode("$escapedGroup")
+            val escapedName = decode("$escapedName")
+            val escapedPluginId = decode("$escapedPluginId")
 
             val catalogVerification = configurations.create("catalogVerification") {
                 isCanBeResolved = false
@@ -502,6 +533,41 @@ class PortableVersionCatalogGeneratorPluginTest {
                     check(Versions.Plugins.pluginVersionRef.version.requiredVersion == "1.2.3")
 
                     check(bundle.get().size == 2)
+
+                    check(
+                        Versions.Versions.versionEscaped.requiredVersion == escapedRequired
+                    )
+                    check(
+                        Versions.Versions.versionEscapedRich.strictVersion == escapedStrict
+                    )
+                    check(
+                        Versions.Versions.versionEscapedRich.requiredVersion == escapedStrict
+                    )
+                    check(
+                        Versions.Versions.versionEscapedRich.preferredVersion == escapedPreferred
+                    )
+                    check(
+                        Versions.Versions.versionEscapedRich.rejectedVersions == escapedRejected
+                    )
+
+                    val escapedLibrary = Versions.Libraries.libEscaped
+                    check(escapedLibrary.group == escapedGroup)
+                    check(escapedLibrary.name == escapedName)
+                    check(escapedLibrary.versionConstraint.strictVersion == escapedStrict)
+                    check(
+                        escapedLibrary.versionConstraint.preferredVersion == escapedPreferred
+                    )
+                    check(
+                        escapedLibrary.versionConstraint.rejectedVersions == escapedRejected
+                    )
+
+                    val escapedPlugin = Versions.Plugins.pluginEscaped
+                    check(escapedPlugin.pluginId == escapedPluginId)
+                    check(escapedPlugin.version.strictVersion == escapedStrict)
+                    check(escapedPlugin.version.preferredVersion == escapedPreferred)
+                    check(escapedPlugin.version.rejectedVersions == escapedRejected)
+
+                    check(escapedBundle.get().single() == escapedLibrary)
                 }
             }
             """.trimIndent()
@@ -543,6 +609,9 @@ class PortableVersionCatalogGeneratorPluginTest {
             """.trimIndent()
         )
     }
+
+    private fun String.toBase64(): String =
+        java.util.Base64.getEncoder().encodeToString(toByteArray(Charsets.UTF_8))
 
     private fun writeMinimalTomlFile(file: File) {
         file.writeText(

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
@@ -42,7 +42,7 @@ class PortableVersionCatalogGeneratorPluginTest {
         writeBuildFile()
 
         // 2. Create file versions.toml
-        writeTomlFile()
+        copyVersionCatalogFixture()
 
         val srcMainKotlin = projectDir.resolve("src/main/kotlin")
         val srcMainJava = projectDir.resolve("src/main/java")
@@ -101,7 +101,7 @@ class PortableVersionCatalogGeneratorPluginTest {
     @Test
     fun `generated catalog exposes public Gradle types and preserves rich versions`() {
         writeBuildFile()
-        writeTomlFile()
+        copyVersionCatalogFixture()
 
         val producerResult = runner("jar").build()
         assertEquals(TaskOutcome.SUCCESS, producerResult.task(":jar")?.outcome)
@@ -395,42 +395,17 @@ class PortableVersionCatalogGeneratorPluginTest {
             .withPluginClasspath()
             .withArguments(*arguments)
 
-    private fun writeTomlFile() {
+    private fun copyVersionCatalogFixture() {
         val tomlFile = projectDir.resolve(versionsFileName)
-        tomlFile.writeText(
-            """
-            [versions]
+        val catalogResource = requireNotNull(
+            javaClass.getResourceAsStream("/libs.versions.toml")
+        ) {
+            "Test version catalog resource '/libs.versions.toml' was not found"
+        }
 
-            version-simple = "1.2.3"
-            version-as-object = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] }
-            version-reject-all = { rejectAll = true }
-            version-escaped = 'required-${'$'}value-\path-"quoted"-end'
-            version-escaped-rich = { prefer = 'prefer-${'$'}value-\path-"quoted"-end', require = 'require-${'$'}value-\path-"quoted"-end', strictly = 'strict-${'$'}value-\path-"quoted"-end', reject = ['reject-${'$'}one-\path-"quoted"-end', 'reject-${'$'}two-\path-"quoted"-end'] }
-
-            [libraries]
-
-            lib-simple-with-version = "com.mycompany:mylib:1.4"
-            lib-simple-no-version.module = "com.mycompany:mylib"
-            lib-module = { module = "com.mycompany:other", version = "1.4" }
-            lib-with-version-ref = { group = "lib.test.version.ref", name = "version-ref", version.ref = "version-simple" }
-            lib-with-version-as-object = { group = "lib.test.version.as.object", name = "version-as-object", version = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] } }
-            lib-escaped = { group = 'com.example.${'$'}group\path"quoted"-end', name = 'lib-${'$'}name\path"quoted"-end', version.ref = "version-escaped-rich" }
-
-            [bundles]
-
-            test-bundle = ["lib-module", "lib-with-version-ref"]
-            test-bundle-simple = ["lib-simple-with-version", "lib-with-version-as-object"]
-            escaped-bundle = ["lib-escaped"]
-
-            [plugins]
-
-            plugin-simple-version = { id = "com.github.ben-manes.versions", version = "0.45.0" }
-            plugin-version-ref = { id = "com.test.plugin-version-ref", version.ref = "version-simple" }
-            plugin-version-as-object = { id = "com.test.version-as-object", version = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] } }
-            plugin-escaped = { id = 'com.example.${'$'}plugin\path"quoted"-end', version.ref = "version-escaped-rich" }
-            plugin-simple-id.id = "com.text.plugin-with-id"
-            """.trimIndent()
-        )
+        catalogResource.use { input ->
+            tomlFile.outputStream().use(input::copyTo)
+        }
     }
 
     private fun writeConsumerBuild(consumerDir: File, producerJar: File) {

--- a/plugin/src/test/resources/libs.versions.toml
+++ b/plugin/src/test/resources/libs.versions.toml
@@ -3,6 +3,8 @@
 version-simple = "1.2.3"
 version-as-object = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] }
 version-reject-all = { rejectAll = true }
+version-escaped = 'required-$value-\path-"quoted"-end'
+version-escaped-rich = { prefer = 'prefer-$value-\path-"quoted"-end', require = 'require-$value-\path-"quoted"-end', strictly = 'strict-$value-\path-"quoted"-end', reject = ['reject-$one-\path-"quoted"-end', 'reject-$two-\path-"quoted"-end'] }
 
 [libraries]
 
@@ -11,16 +13,18 @@ lib-simple-no-version.module = "com.mycompany:mylib"
 lib-module = { module = "com.mycompany:other", version = "1.4" }
 lib-with-version-ref = { group = "lib.test.version.ref", name = "version-ref", version.ref = "version-simple" }
 lib-with-version-as-object = { group = "lib.test.version.as.object", name = "version-as-object", version = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] } }
-
+lib-escaped = { group = 'com.example.$group\path"quoted"-end', name = 'lib-$name\path"quoted"-end', version.ref = "version-escaped-rich" }
 
 [bundles]
 
 test-bundle = ["lib-module", "lib-with-version-ref"]
 test-bundle-simple = ["lib-simple-with-version", "lib-with-version-as-object"]
+escaped-bundle = ["lib-escaped"]
 
 [plugins]
 
 plugin-simple-version = { id = "com.github.ben-manes.versions", version = "0.45.0" }
 plugin-version-ref = { id = "com.test.plugin-version-ref", version.ref = "version-simple" }
 plugin-version-as-object = { id = "com.test.version-as-object", version = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] } }
+plugin-escaped = { id = 'com.example.$plugin\path"quoted"-end', version.ref = "version-escaped-rich" }
 plugin-simple-id.id = "com.text.plugin-with-id"


### PR DESCRIPTION
## Summary
- escape all external string values before embedding them in generated Kotlin source
- preserve the exact TOML values for required, preferred, strict, and rejected versions as well as library coordinates and plugin IDs
- sanitize the project version used in generated KDoc
- add unit coverage for Kotlin syntax, controls, and Unicode plus a compiled producer/consumer round-trip test

## Verification
- `./gradlew :plugin:test --tests 'com.the13haven.gradle.povercat.KotlinSourceEscapingTest'`\n- `./gradlew :plugin:test --tests 'com.the13haven.gradle.povercat.PortableVersionCatalogGeneratorPluginTest.generated catalog exposes public Gradle types and preserves rich versions'`\n- `./gradlew clean check`