### PR TITLE
Normalize version catalog aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ when PoVerCat finds invalid TOML, malformed library or version declarations,
 unknown `version.ref` values, or unknown library aliases in a bundle. Libraries
 and plugins without a version remain supported.
 
+Aliases follow Gradle normalization rules: `-`, `_`, and `.` are equivalent
+separators for `version.ref` and bundle references. Generated accessors remain
+flat camel-case names, so `foo-bar`, `foo_bar`, and `foo.bar` all map to
+`fooBar`; a version alias therefore always produces one property in the
+`Versions` object rather than nested accessors. To keep the generated API
+deterministic, PoVerCat rejects declarations that become duplicates after
+normalization, distinct aliases that generate the same accessor, invalid alias
+characters, and reserved Gradle, Java, or Kotlin names. `*` is not a Gradle
+alias separator and is rejected rather than normalized.
+
 The default package for the generated classes is `org.gradle.version.catalog`. This too can be customized via plugin configuration.
 
 By default, the generated source files are placed under `build/generated/sources`. You can also override this output directory if needed.

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/CatalogAlias.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/CatalogAlias.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.the13haven.gradle.povercat
+
+/**
+ * Applies Gradle-compatible alias normalization and PoVerCat accessor naming.
+ */
+internal object CatalogAlias {
+
+    private val separator = Regex("[_.-]")
+    private val validAlias = Regex("[a-z][a-zA-Z0-9_.-]+")
+
+    val reservedAliasNames: Set<String> = setOf("extensions", "convention")
+    val reservedJavaSegments: Set<String> = setOf("class")
+    val forbiddenLibraryPrefixes: Set<String> = setOf("bundles", "versions", "plugins")
+
+    private val kotlinKeywords = setOf(
+        "as",
+        "break",
+        "class",
+        "continue",
+        "do",
+        "else",
+        "false",
+        "for",
+        "fun",
+        "if",
+        "in",
+        "interface",
+        "is",
+        "null",
+        "object",
+        "package",
+        "return",
+        "super",
+        "this",
+        "throw",
+        "true",
+        "try",
+        "typealias",
+        "typeof",
+        "val",
+        "var",
+        "when",
+        "while"
+    )
+
+    fun normalize(alias: String): String =
+        alias.replace(separator, ".")
+
+    fun toAccessorName(alias: String): String =
+        normalize(alias)
+            .split('.')
+            .joinToString(separator = "") { segment ->
+                segment.replaceFirstChar { character ->
+                    character.uppercaseChar().toString()
+                }
+            }
+            .replaceFirstChar { character ->
+                character.lowercaseChar().toString()
+            }
+
+    fun isValid(alias: String): Boolean =
+        validAlias.matches(alias)
+
+    fun isReservedAccessor(accessorName: String): Boolean =
+        accessorName in kotlinKeywords
+}

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogClassGenerator.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogClassGenerator.kt
@@ -89,7 +89,7 @@ class PortableVersionCatalogClassGenerator {
                         val parsedVersion = TomlParserUtils.parseVersion(value)
 
                         if (parsedVersion.isNotEmpty()) {
-                            parsedVersions[key] = parsedVersion
+                            parsedVersions[CatalogAlias.normalize(key)] = parsedVersion
 
                             appendLine()
                             appendLine("        @JvmStatic")

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/TomlParserUtils.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/TomlParserUtils.kt
@@ -17,7 +17,6 @@ package com.the13haven.gradle.povercat
 
 import org.tomlj.TomlArray
 import org.tomlj.TomlTable
-import java.util.Locale
 
 
 /**
@@ -52,20 +51,8 @@ class TomlParserUtils {
         val REJECT_ALL_VERSION = TomlVersion(EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, listOf("+"))
 
         @JvmStatic
-        fun toCamelCase(value: String): String {
-            return value.split("-", "_", ".")
-                .joinToString(EMPTY_STRING) { part ->
-                    part.replaceFirstChar {
-                        if (it.isLowerCase())
-                            it.titlecase(Locale.getDefault())
-                        else
-                            it.toString()
-                    }
-                }
-                .replaceFirstChar {
-                    it.lowercase(Locale.getDefault())
-                }
-        }
+        fun toCamelCase(value: String): String =
+            CatalogAlias.toAccessorName(value)
 
         @JvmStatic
         fun parseVersion(versionValue: Any): TomlVersion {
@@ -151,7 +138,10 @@ class TomlParserUtils {
                         parseVersion(versionPart)
                     } else {
                         // case 3: ref to version
-                        versions.getOrDefault(refVersionKey, EMPTY_VERSION)
+                        versions.getOrDefault(
+                            CatalogAlias.normalize(refVersionKey),
+                            EMPTY_VERSION
+                        )
                     }
                 } else {
                     // case 4: simple version

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/VersionCatalogValidator.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/VersionCatalogValidator.kt
@@ -45,10 +45,19 @@ internal object VersionCatalogValidator {
         val plugins = catalog.section("plugins", errors)
         val bundles = catalog.section("bundles", errors)
 
+        val versionAliases = versions
+            ?.validateAliases("versions", errors)
+            .orEmpty()
+        val libraryAliases = libraries
+            ?.validateAliases("libraries", errors)
+            .orEmpty()
+        plugins?.validateAliases("plugins", errors)
+        bundles?.validateAliases("bundles", errors)
+
         versions?.validateVersions(errors)
-        libraries?.validateLibraries(versions?.keySet().orEmpty(), errors)
-        plugins?.validatePlugins(versions?.keySet().orEmpty(), errors)
-        bundles?.validateBundles(libraries?.keySet().orEmpty(), errors)
+        libraries?.validateLibraries(versionAliases, errors)
+        plugins?.validatePlugins(versionAliases, errors)
+        bundles?.validateBundles(libraryAliases, errors)
 
         if (errors.isNotEmpty()) {
             throw invalidCatalog(
@@ -69,6 +78,92 @@ internal object VersionCatalogValidator {
                 errors += "[$sectionName] must be a TOML table."
                 null
             }
+        }
+
+    private fun TomlTable.validateAliases(
+        sectionName: String,
+        errors: MutableList<String>
+    ): Set<String> {
+        val aliases = keySet().sorted()
+        val validAliases = aliases.filter { alias ->
+            if (CatalogAlias.isValid(alias)) {
+                true
+            } else {
+                errors +=
+                    "${aliasLocation(sectionName, alias)} must match Gradle alias pattern " +
+                        "'[a-z][a-zA-Z0-9_.-]+'."
+                false
+            }
+        }
+
+        validAliases.forEach { alias ->
+            validateReservedAlias(sectionName, alias, errors)
+        }
+
+        validAliases
+            .groupBy(CatalogAlias::normalize)
+            .filterValues { matchingAliases -> matchingAliases.size > 1 }
+            .forEach { (normalizedAlias, matchingAliases) ->
+                errors +=
+                    "[$sectionName] aliases ${matchingAliases.renderAliases(this)} " +
+                        "normalize to the same Gradle alias '$normalizedAlias'. Rename one alias."
+            }
+
+        validAliases
+            .groupBy(CatalogAlias::toAccessorName)
+            .filterValues { matchingAliases ->
+                matchingAliases
+                    .map(CatalogAlias::normalize)
+                    .distinct()
+                    .size > 1
+            }
+            .forEach { (accessorName, matchingAliases) ->
+                errors +=
+                    "[$sectionName] aliases ${matchingAliases.renderAliases(this)} " +
+                        "generate the same accessor '$accessorName'. Rename one alias."
+            }
+
+        return validAliases
+            .map(CatalogAlias::normalize)
+            .toSet()
+    }
+
+    private fun TomlTable.validateReservedAlias(
+        sectionName: String,
+        alias: String,
+        errors: MutableList<String>
+    ) {
+        val normalizedAlias = CatalogAlias.normalize(alias)
+        val segments = normalizedAlias.split('.')
+        val location = aliasLocation(sectionName, alias)
+
+        when {
+            normalizedAlias in CatalogAlias.reservedAliasNames ->
+                errors += "$location uses a reserved Gradle alias name '$normalizedAlias'."
+
+            segments.any { segment -> segment in CatalogAlias.reservedJavaSegments } ->
+                errors += "$location contains reserved Java name 'class'."
+
+            sectionName == "libraries" &&
+                segments.first() in CatalogAlias.forbiddenLibraryPrefixes ->
+                errors +=
+                    "$location starts with reserved library prefix '${segments.first()}'."
+        }
+
+        val accessorName = CatalogAlias.toAccessorName(alias)
+        if (CatalogAlias.isReservedAccessor(accessorName)) {
+            errors +=
+                "$location generates reserved Kotlin accessor name '$accessorName'. " +
+                    "Rename the alias."
+        }
+    }
+
+    private fun TomlTable.aliasLocation(sectionName: String, alias: String): String =
+        "[$sectionName].$alias (${inputPositionOf(listOf(alias)).render()})"
+
+    private fun List<String>.renderAliases(table: TomlTable): String =
+        sorted().joinToString(separator = ", ") { alias ->
+            "'$alias' (${table.inputPositionOf(listOf(alias)).render()})"
         }
 
     private fun TomlTable.validateVersions(errors: MutableList<String>) {
@@ -158,7 +253,12 @@ internal object VersionCatalogValidator {
                     libraryAlias !is String ->
                         errors += "$location[$index] must be a library alias string."
 
-                    libraryAlias !in libraryAliases ->
+                    !CatalogAlias.isValid(libraryAlias) ->
+                        errors +=
+                            "$location[$index] must match Gradle alias pattern " +
+                                "'[a-z][a-zA-Z0-9_.-]+'."
+
+                    CatalogAlias.normalize(libraryAlias) !in libraryAliases ->
                         errors += "$location references unknown library alias '$libraryAlias'."
                 }
             }
@@ -187,7 +287,12 @@ internal object VersionCatalogValidator {
                         reference !is String || reference.isBlank() ->
                             errors += "$ownerLocation.version.ref must be a non-empty string."
 
-                        reference !in versionAliases ->
+                        !CatalogAlias.isValid(reference) ->
+                            errors +=
+                                "$ownerLocation.version.ref must match Gradle alias pattern " +
+                                    "'[a-z][a-zA-Z0-9_.-]+'."
+
+                        CatalogAlias.normalize(reference) !in versionAliases ->
                             errors +=
                                 "$ownerLocation references unknown version alias '$reference'."
                     }
@@ -276,7 +381,7 @@ internal object VersionCatalogValidator {
         action: (alias: String, value: Any, location: String) -> Unit
     ) {
         entrySet().forEach { (alias, value) ->
-            val position = inputPositionOf(alias)
+            val position = inputPositionOf(listOf(alias))
             action(alias, value, "[$sectionName].$alias (${position.render()})")
         }
     }

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/CatalogAliasTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/CatalogAliasTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.the13haven.gradle.povercat
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CatalogAliasTest {
+
+    @Test
+    fun `normalizes Gradle alias separators to dots`() {
+        assertEquals("foo.bar", CatalogAlias.normalize("foo-bar"))
+        assertEquals("foo.bar", CatalogAlias.normalize("foo_bar"))
+        assertEquals("foo.bar", CatalogAlias.normalize("foo.bar"))
+        assertEquals("foo..bar", CatalogAlias.normalize("foo-_bar"))
+    }
+
+    @Test
+    fun `generates one flat camel-case accessor for every separator`() {
+        assertEquals("fooBar", CatalogAlias.toAccessorName("foo-bar"))
+        assertEquals("fooBar", CatalogAlias.toAccessorName("foo_bar"))
+        assertEquals("fooBar", CatalogAlias.toAccessorName("foo.bar"))
+        assertEquals("fooBar", CatalogAlias.toAccessorName("foo-_bar"))
+    }
+
+    @Test
+    fun `validates Gradle-compatible alias characters`() {
+        assertTrue(CatalogAlias.isValid("foo-bar_2.version"))
+        assertFalse(CatalogAlias.isValid("foo*_bar"))
+        assertFalse(CatalogAlias.isValid("Foo"))
+        assertFalse(CatalogAlias.isValid("f"))
+    }
+
+    @Test
+    fun `recognizes Kotlin keywords that cannot be generated as properties`() {
+        assertTrue(CatalogAlias.isReservedAccessor("when"))
+        assertTrue(CatalogAlias.isReservedAccessor("object"))
+        assertFalse(CatalogAlias.isReservedAccessor("fooWhen"))
+    }
+}

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
@@ -122,6 +122,11 @@ class PortableVersionCatalogGeneratorPluginTest {
         )
         assertTrue(generatedCatalog.contains("val pluginVersionAsObject: PluginDependency"))
         assertTrue(generatedCatalog.contains("val versionAsObject: VersionConstraint"))
+        assertTrue(
+            generatedCatalog.contains(
+                "val versionEscapedRich: VersionConstraint"
+            )
+        )
 
         val producerJar = projectDir.resolve("build/libs")
             .listFiles { file -> file.extension == "jar" }
@@ -211,6 +216,24 @@ class PortableVersionCatalogGeneratorPluginTest {
         assertTrue(result.output.contains(projectDir.resolve(versionsFileName).absolutePath))
         assertTrue(result.output.contains("[libraries].invalid-library"))
         assertTrue(result.output.contains("references unknown version alias 'missing'"))
+    }
+
+    @Test
+    fun `fail fast when aliases collide after Gradle normalization`() {
+        writeBuildFile()
+        copyVersionCatalogFixture(
+            "/aliases/normalized-duplicates.versions.toml"
+        )
+
+        val result = runner("generatePortableVersionCatalog").buildAndFail()
+
+        assertTrue(result.output.contains("Invalid version catalog"))
+        assertTrue(
+            result.output.contains(
+                "normalize to the same Gradle alias 'foo.bar'"
+            )
+        )
+        assertTrue(result.output.contains("Rename one alias"))
     }
 
     @Test
@@ -395,12 +418,14 @@ class PortableVersionCatalogGeneratorPluginTest {
             .withPluginClasspath()
             .withArguments(*arguments)
 
-    private fun copyVersionCatalogFixture() {
+    private fun copyVersionCatalogFixture(
+        resourcePath: String = "/libs.versions.toml"
+    ) {
         val tomlFile = projectDir.resolve(versionsFileName)
         val catalogResource = requireNotNull(
-            javaClass.getResourceAsStream("/libs.versions.toml")
+            javaClass.getResourceAsStream(resourcePath)
         ) {
-            "Test version catalog resource '/libs.versions.toml' was not found"
+            "Test version catalog resource '$resourcePath' was not found"
         }
 
         catalogResource.use { input ->

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/VersionCatalogValidatorTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/VersionCatalogValidatorTest.kt
@@ -155,10 +155,107 @@ class VersionCatalogValidatorTest {
         VersionCatalogValidator.validate(catalog, Toml.parse(catalog.toPath()))
     }
 
+    @Test
+    fun `allows Gradle-normalized version and bundle references`() {
+        val catalog = catalogResource("normalized-references.versions.toml")
+
+        VersionCatalogValidator.validate(catalog, Toml.parse(catalog.toPath()))
+    }
+
+    @Test
+    fun `rejects aliases that are duplicates after Gradle normalization`() {
+        val catalog = catalogResource("normalized-duplicates.versions.toml")
+
+        val exception = validateAndCapture(catalog)
+
+        listOf("versions", "libraries", "bundles", "plugins").forEach { section ->
+            assertTrue(
+                exception.message!!.contains(
+                    "[$section] aliases"
+                )
+            )
+        }
+        assertTrue(
+            exception.message!!.contains(
+                "normalize to the same Gradle alias 'foo.bar'"
+            )
+        )
+        assertTrue(exception.message!!.contains("Rename one alias"))
+    }
+
+    @Test
+    fun `rejects distinct aliases that generate the same flat accessor`() {
+        val catalog = catalogResource("accessor-collisions.versions.toml")
+
+        val exception = validateAndCapture(catalog)
+
+        assertTrue(
+            exception.message!!.contains(
+                "[versions] aliases 'some-alias'"
+            )
+        )
+        assertTrue(exception.message!!.contains("same accessor 'someAlias'"))
+        assertTrue(exception.message!!.contains("same accessor 'libraryAlias'"))
+        assertTrue(exception.message!!.contains("same accessor 'bundleAlias'"))
+        assertTrue(exception.message!!.contains("same accessor 'pluginAlias'"))
+    }
+
+    @Test
+    fun `rejects invalid and reserved aliases before source generation`() {
+        val catalog = catalogResource("invalid-and-reserved.versions.toml")
+
+        val exception = validateAndCapture(catalog)
+
+        assertTrue(exception.message!!.contains("[versions].foo*_bar"))
+        assertTrue(exception.message!!.contains("must match Gradle alias pattern"))
+        assertTrue(exception.message!!.contains("reserved Kotlin accessor name 'when'"))
+        assertTrue(exception.message!!.contains("reserved Gradle alias name 'extensions'"))
+        assertTrue(exception.message!!.contains("reserved Java name 'class'"))
+        assertTrue(exception.message!!.contains("reserved library prefix 'versions'"))
+    }
+
+    @Test
+    fun `rejects invalid aliases in version and bundle references`() {
+        val catalog = catalogResource("invalid-references.versions.toml")
+
+        val exception = validateAndCapture(catalog)
+
+        assertTrue(
+            exception.message!!.contains(
+                "[libraries].invalid-version-reference"
+            )
+        )
+        assertTrue(
+            exception.message!!.contains(
+                ".version.ref must match Gradle alias pattern"
+            )
+        )
+        assertTrue(
+            exception.message!!.contains(
+                "[bundles].invalid-bundle-reference"
+            )
+        )
+        assertTrue(exception.message!!.contains("[0] must match Gradle alias pattern"))
+    }
+
     private fun catalogFile(content: String): File =
         tempDir.resolve("libs.versions.toml").apply {
             writeText(content.trimIndent())
         }
+
+    private fun catalogResource(resourceName: String): File {
+        val catalog = tempDir.resolve(resourceName)
+        val resource = requireNotNull(
+            javaClass.getResourceAsStream("/aliases/$resourceName")
+        ) {
+            "Test version catalog resource '/aliases/$resourceName' was not found"
+        }
+
+        resource.use { input ->
+            catalog.outputStream().use(input::copyTo)
+        }
+        return catalog
+    }
 
     private fun validateAndCapture(catalog: File): GradleException =
         assertThrows {

--- a/plugin/src/test/resources/aliases/accessor-collisions.versions.toml
+++ b/plugin/src/test/resources/aliases/accessor-collisions.versions.toml
@@ -1,0 +1,15 @@
+[versions]
+someAlias = "1.2.3"
+some-alias = "2.0.0"
+
+[libraries]
+libraryAlias = "com.example:first:1.0"
+library-alias = "com.example:second:2.0"
+
+[bundles]
+bundleAlias = ["libraryAlias"]
+bundle-alias = ["library-alias"]
+
+[plugins]
+pluginAlias = { id = "com.example.first", version = "1.0" }
+plugin-alias = { id = "com.example.second", version = "2.0" }

--- a/plugin/src/test/resources/aliases/invalid-and-reserved.versions.toml
+++ b/plugin/src/test/resources/aliases/invalid-and-reserved.versions.toml
@@ -1,0 +1,8 @@
+[versions]
+"foo*_bar" = "1.0"
+when = "2.0"
+extensions = "3.0"
+class = "4.0"
+
+[libraries]
+versions-dependency = "com.example:dependency:1.0"

--- a/plugin/src/test/resources/aliases/invalid-references.versions.toml
+++ b/plugin/src/test/resources/aliases/invalid-references.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+valid-version = "1.0"
+
+[libraries]
+valid-library = "com.example:valid:1.0"
+invalid-version-reference = { module = "com.example:invalid", version.ref = "valid*version" }
+
+[bundles]
+invalid-bundle-reference = ["valid*library"]

--- a/plugin/src/test/resources/aliases/normalized-duplicates.versions.toml
+++ b/plugin/src/test/resources/aliases/normalized-duplicates.versions.toml
@@ -1,0 +1,15 @@
+[versions]
+foo-bar = "1.2.3"
+foo_bar = "2.0.0"
+
+[libraries]
+library-alias = "com.example:first:1.0"
+library_alias = "com.example:second:2.0"
+
+[bundles]
+bundle-alias = ["library-alias"]
+bundle_alias = ["library_alias"]
+
+[plugins]
+plugin-alias = { id = "com.example.first", version = "1.0" }
+plugin_alias = { id = "com.example.second", version = "2.0" }

--- a/plugin/src/test/resources/aliases/normalized-references.versions.toml
+++ b/plugin/src/test/resources/aliases/normalized-references.versions.toml
@@ -1,0 +1,11 @@
+[versions]
+foo-bar = "1.2.3"
+
+[libraries]
+library-alias = { module = "com.example:library", version.ref = "foo_bar" }
+
+[bundles]
+bundle-alias = ["library.alias"]
+
+[plugins]
+plugin-alias = { id = "com.example.plugin", version.ref = "foo.bar" }

--- a/plugin/src/test/resources/libs.versions.toml
+++ b/plugin/src/test/resources/libs.versions.toml
@@ -4,7 +4,7 @@ version-simple = "1.2.3"
 version-as-object = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] }
 version-reject-all = { rejectAll = true }
 version-escaped = 'required-$value-\path-"quoted"-end'
-version-escaped-rich = { prefer = 'prefer-$value-\path-"quoted"-end', require = 'require-$value-\path-"quoted"-end', strictly = 'strict-$value-\path-"quoted"-end', reject = ['reject-$one-\path-"quoted"-end', 'reject-$two-\path-"quoted"-end'] }
+"version.escaped.rich" = { prefer = 'prefer-$value-\path-"quoted"-end', require = 'require-$value-\path-"quoted"-end', strictly = 'strict-$value-\path-"quoted"-end', reject = ['reject-$one-\path-"quoted"-end', 'reject-$two-\path-"quoted"-end'] }
 
 [libraries]
 
@@ -13,13 +13,13 @@ lib-simple-no-version.module = "com.mycompany:mylib"
 lib-module = { module = "com.mycompany:other", version = "1.4" }
 lib-with-version-ref = { group = "lib.test.version.ref", name = "version-ref", version.ref = "version-simple" }
 lib-with-version-as-object = { group = "lib.test.version.as.object", name = "version-as-object", version = { prefer = "1.0.0", require = "1.0.1", strictly = "1.1.1", reject = ["0.0.1", "0.0.2"] } }
-lib-escaped = { group = 'com.example.$group\path"quoted"-end', name = 'lib-$name\path"quoted"-end', version.ref = "version-escaped-rich" }
+lib-escaped = { group = 'com.example.$group\path"quoted"-end', name = 'lib-$name\path"quoted"-end', version.ref = "version_escaped_rich" }
 
 [bundles]
 
 test-bundle = ["lib-module", "lib-with-version-ref"]
 test-bundle-simple = ["lib-simple-with-version", "lib-with-version-as-object"]
-escaped-bundle = ["lib-escaped"]
+escaped-bundle = ["lib.escaped"]
 
 [plugins]
 


### PR DESCRIPTION
## Summary
- normalize `-`, `_`, and `.` in aliases and references using Gradle semantics
- generate one flat camel-case accessor for version aliases, including dotted aliases
- reject normalized duplicates, generated accessor clashes, invalid alias characters, and reserved Gradle/Java/Kotlin names with actionable errors
- resolve `version.ref` and bundle entries through normalized aliases
- make accessor generation locale-independent and document the behavior

`*` is not a valid Gradle alias separator and is rejected.

## Tests
- resource-based TOML fixtures for normalized references, normalized duplicates, accessor clashes, invalid aliases, reserved names, and invalid references
- functional producer/consumer round-trip with a dotted version alias referenced through `_` and `-`
- TestKit fail-fast coverage for normalized duplicates
- `./gradlew clean check`
- `./gradlew check`

All 49 tests, plugin validation, and JaCoCo coverage verification pass.