### PR TITLE
Fix default generated sources directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ portableVersionCatalog {
 
 With an empty collection, the generation task is skipped when there are no outputs
 to clean up. PoVerCat tracks the files it owns in
-`build/generated/sources/.povercat-generated-files` and removes obsolete generated
-classes when a configured catalog is removed or renamed. Do not edit this manifest
-manually.
+`build/generated/sources/povercat/.povercat-generated-files` and removes obsolete
+generated classes when a configured catalog is removed or renamed. Do not edit this
+manifest manually.
 
 PoVerCat validates every configured catalog before generating source code. This is
 necessary because custom files from `tomlFiles` are not necessarily imported by
@@ -117,7 +117,9 @@ alias separator and is rejected rather than normalized.
 
 The default package for the generated classes is `org.gradle.version.catalog`. This too can be customized via plugin configuration.
 
-By default, the generated source files are placed under `build/generated/sources`. You can also override this output directory if needed.
+By default, the generated source files are placed under
+`build/generated/sources/povercat`. PoVerCat automatically registers this directory
+as a source directory, including when `outputDir` is overridden.
 
 Below is an example of how to override the default settings in `build.gradle.kts`:
 
@@ -125,7 +127,7 @@ Below is an example of how to override the default settings in `build.gradle.kts
 portableVersionCatalog {
     tomlFiles.setFrom("${projectDir.absolutePath}/catalog/libs-main.versions.toml")
     catalogPackage.set("com.example.catalog")
-    outputDir.set(file("build/generated/sources"))
+    outputDir.set(layout.buildDirectory.dir("generated/sources/custom-catalogs"))
 }
 ```
 

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginExtension.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginExtension.kt
@@ -45,16 +45,7 @@ open class PortableVersionCatalogGeneratorPluginExtension(project: Project) {
 
     val outputDir: DirectoryProperty = project.objects
         .directoryProperty()
-        .convention(
-            project.objects
-                .directoryProperty()
-                .fileValue(
-                    project.layout
-                        .buildDirectory.dir("build/generated/sources")
-                        .get()
-                        .asFile
-                )
-        )
+        .convention(project.layout.buildDirectory.dir("generated/sources/povercat"))
 
     companion object {
         fun Project.portableVersionCatalog(): PortableVersionCatalogGeneratorPluginExtension =

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginExtensionTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginExtensionTest.kt
@@ -75,7 +75,11 @@ class PortableVersionCatalogGeneratorPluginExtensionTest {
 
     @Test
     fun `should have default outputDir value`() {
-        val expectedDir = project.layout.buildDirectory.dir("build/generated/sources").get().asFile
+        val expectedDir = project.layout.buildDirectory
+            .dir("generated/sources/povercat")
+            .get()
+            .asFile
+
         assertEquals(expectedDir, extension.outputDir.get().asFile)
     }
 

--- a/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTest.kt
@@ -35,11 +35,13 @@ class PortableVersionCatalogGeneratorPluginTest {
     lateinit var projectDir: File
 
     private val versionsFileName = "versions.toml"
+    private val defaultGeneratedSourcesPath = "build/generated/sources/povercat"
 
     @Test
     fun `generate catalog with reusable configuration cache`() {
         // 1. Create test build.gradle.kts
-        writeBuildFile()
+        val generatedSourcesPath = "build/generated/sources"
+        writeBuildFile(outputDir = generatedSourcesPath)
 
         // 2. Create file versions.toml
         copyVersionCatalogFixture()
@@ -78,7 +80,7 @@ class PortableVersionCatalogGeneratorPluginTest {
         assertTrue(secondRun.output.contains("Configuration cache entry reused."))
 
         // 5. Check files
-        val generatedDir = projectDir.resolve("build/generated/sources")
+        val generatedDir = projectDir.resolve(generatedSourcesPath)
         assertTrue(generatedDir.exists())
         val generatedCatalog = generatedDir.resolve("com/example/catalog/VersionsCatalog.kt")
         assertTrue(generatedCatalog.exists())
@@ -86,9 +88,13 @@ class PortableVersionCatalogGeneratorPluginTest {
         assertTrue(
             projectDir.resolve("build/classes/kotlin/main/com/example/catalog/Versions.class").exists()
         )
+        assertFalse(projectDir.resolve("build/build/generated/sources").exists())
 
         // 6. Change a declared task input and verify the catalog is regenerated
-        writeBuildFile(projectVersion = "2.0.0")
+        writeBuildFile(
+            projectVersion = "2.0.0",
+            outputDir = generatedSourcesPath
+        )
 
         val thirdRun = runner.build()
         assertEquals(
@@ -96,6 +102,30 @@ class PortableVersionCatalogGeneratorPluginTest {
             thirdRun.task(":generatePortableVersionCatalog")?.outcome
         )
         assertTrue(generatedCatalog.readText().contains("@version v2.0.0"))
+    }
+
+    @Test
+    fun `compile catalog from custom output directory without source set configuration`() {
+        val customOutputPath = "custom/generated/povercat"
+        writeBuildFile(outputDir = customOutputPath)
+        copyVersionCatalogFixture()
+
+        val result = runner("compileKotlin").build()
+
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            result.task(":generatePortableVersionCatalog")?.outcome
+        )
+        assertTrue(
+            projectDir.resolve(
+                "$customOutputPath/com/example/catalog/VersionsCatalog.kt"
+            ).exists()
+        )
+        assertTrue(
+            projectDir.resolve(
+                "build/classes/kotlin/main/com/example/catalog/Versions.class"
+            ).exists()
+        )
     }
 
     @Test
@@ -107,7 +137,7 @@ class PortableVersionCatalogGeneratorPluginTest {
         assertEquals(TaskOutcome.SUCCESS, producerResult.task(":jar")?.outcome)
 
         val generatedCatalog = projectDir.resolve(
-            "build/generated/sources/com/example/catalog/VersionsCatalog.kt"
+            "$defaultGeneratedSourcesPath/com/example/catalog/VersionsCatalog.kt"
         ).readText()
         assertTrue(
             generatedCatalog.contains(
@@ -176,7 +206,7 @@ class PortableVersionCatalogGeneratorPluginTest {
             TaskOutcome.SKIPPED,
             result.task(":generatePortableVersionCatalog")?.outcome
         )
-        assertFalse(projectDir.resolve("build/generated/sources").exists())
+        assertFalse(projectDir.resolve(defaultGeneratedSourcesPath).exists())
     }
 
     @Test
@@ -271,7 +301,9 @@ class PortableVersionCatalogGeneratorPluginTest {
             successfulResult.task(":generatePortableVersionCatalog")?.outcome
         )
 
-        val generatedPackage = projectDir.resolve("build/generated/sources/com/example/catalog")
+        val generatedPackage = projectDir.resolve(
+            "$defaultGeneratedSourcesPath/com/example/catalog"
+        )
         assertTrue(
             generatedPackage.resolve("TeamAVersionsCatalog.kt")
                 .readText()
@@ -318,7 +350,7 @@ class PortableVersionCatalogGeneratorPluginTest {
         writeMinimalTomlFile(secondCatalog)
         writeBuildFile(tomlFiles = listOf(firstCatalog, secondCatalog))
 
-        val generatedDir = projectDir.resolve("build/generated/sources")
+        val generatedDir = projectDir.resolve(defaultGeneratedSourcesPath)
         val firstSource = generatedDir.resolve("com/example/catalog/FirstCatalog.kt")
         val secondSource = generatedDir.resolve("com/example/catalog/SecondCatalog.kt")
         val manifest = generatedDir.resolve(
@@ -373,7 +405,8 @@ class PortableVersionCatalogGeneratorPluginTest {
     private fun writeBuildFile(
         projectVersion: String = "1.2.3",
         tomlFiles: List<File>? = listOf(projectDir.resolve(versionsFileName)),
-        catalogClassNames: Map<String, String> = emptyMap()
+        catalogClassNames: Map<String, String> = emptyMap(),
+        outputDir: String? = null
     ) {
         val tomlFilesConfiguration = when {
             tomlFiles == null -> ""
@@ -387,6 +420,9 @@ class PortableVersionCatalogGeneratorPluginTest {
             .joinToString("\n") { (catalogPath, className) ->
                 """catalogClassNames.put("$catalogPath", "$className")"""
             }
+        val outputDirConfiguration = outputDir?.let {
+            """outputDir.set(file("$it"))"""
+        }.orEmpty()
         val buildFile = projectDir.resolve("build.gradle.kts")
         buildFile.writeText(
             """
@@ -404,7 +440,7 @@ class PortableVersionCatalogGeneratorPluginTest {
                 catalogPackage.set("com.example.catalog")
                 $tomlFilesConfiguration
                 $catalogClassNamesConfiguration
-                outputDir.set(file("build/generated/sources"))
+                $outputDirConfiguration
             }
 
             version = "$projectVersion"


### PR DESCRIPTION
## Summary
- use the lazy `build/generated/sources/povercat` convention instead of resolving `build/build/generated/sources` eagerly
- keep generated sources automatically registered for both default and custom output directories
- update README paths and lazy configuration example
- cover the default path, absence of `build/build`, custom output compilation, stale output cleanup, and configuration-cache behavior

## Verification
- `./gradlew clean check --rerun-tasks --console=plain`
- 50 tests passed
- Gradle plugin validation passed
- JaCoCo coverage verification passed