### PR TITLE
Document generation semantics

### DIFF
--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogClassGenerator.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogClassGenerator.kt
@@ -358,6 +358,8 @@ class PortableVersionCatalogClassGenerator {
         }
 
         private fun TomlParseResult.toMap(key: String): Map<String, Any> {
+            // Catalog entry order has no semantic meaning, so generation deliberately uses the
+            // parser-provided iteration order instead of imposing an unrelated canonical sort.
             return getTable(key)?.toMap() ?: emptyMap()
         }
     }

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTask.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTask.kt
@@ -42,10 +42,14 @@ import javax.lang.model.SourceVersion
 /**
  * PoVerCat Plugin Task.
  *
+ * The current year is intentionally not a task input. Generated sources should receive a
+ * fresh year only when another declared input changes; otherwise this task remains UP-TO-DATE.
+ * For the same reason, its outputs must not be restored from a build cache across calendar years.
+ *
  * @author ssidorov@the13haven.com
  */
 @DisableCachingByDefault(
-    because = "Generated source includes the current year, which is not declared as a task input"
+    because = "Generated source intentionally captures the execution year only when other inputs change"
 )
 abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
 


### PR DESCRIPTION
## Summary
- document why the current year is intentionally evaluated only when another declared input triggers generation
- clarify why the task remains excluded from Gradle build-cache restoration across calendar years
- document that TOML catalog entries are intentionally not canonically sorted because their order has no semantic meaning

No functional behavior is changed.

## Verification
- `./gradlew check --console=plain`
- 50 tests passed
- Gradle plugin validation passed
- JaCoCo coverage verification passed