### PR TITLE
Document Java 21 runtime requirement

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -36,6 +36,8 @@ dependencies {
 }
 
 kotlin {
+    // Java 21 is the intentional minimum runtime for PoVerCat. Supporting older JVMs is
+    // out of scope unless explicit community demand justifies widening the compatibility matrix.
     compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
 
     jvmToolchain {


### PR DESCRIPTION
## Summary
- document that Java 21 is the intentional minimum runtime for PoVerCat
- clarify that support for older JVMs is out of scope unless explicit community demand justifies expanding compatibility

No functional behavior is changed.

## Verification
- `./gradlew check --console=plain`
- build successful