### PR TITLE
Make Maven Local resolution opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,15 @@ This approach allows you to build convention plugins with preconfigured tools us
 
 We welcome contributions!
 
+Gradle uses its own dependency cache for released artifacts. Maven Local is
+disabled as a resolution repository by default so that locally published
+artifacts cannot unexpectedly shadow released dependencies or plugins. Enable it
+explicitly when testing a local publication:
+
+```shell
+./gradlew check -PuseMavenLocal=true
+```
+
 ___
 ## License
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -70,8 +70,8 @@ gradlePlugin {
 }
 
 publishing {
-    afterEvaluate {
-        publications.named<MavenPublication>("pluginMaven") {
+    publications.withType<MavenPublication>().configureEach {
+        if (name == "pluginMaven") {
             artifactId = "povercat"
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,18 +2,26 @@ rootProject.name = "gradle-povercat-plugin"
 
 include("plugin")
 
+val useMavenLocal = providers.gradleProperty("useMavenLocal")
+    .map { it.toBooleanStrict() }
+    .getOrElse(false)
+
 dependencyResolutionManagement {
 
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 
     repositories {
-        mavenLocal()
+        if (useMavenLocal) {
+            mavenLocal()
+        }
         mavenCentral()
     }
 
     pluginManagement {
         repositories {
-            mavenLocal()
+            if (useMavenLocal) {
+                mavenLocal()
+            }
             mavenCentral()
             gradlePluginPortal()
         }


### PR DESCRIPTION
## Summary
- use Gradle's dependency cache by default without treating Maven Local as a resolution repository
- allow local publication testing explicitly with `-PuseMavenLocal=true` for both dependencies and plugins
- keep Maven Local available as a publishing destination
- configure the `pluginMaven` artifact ID lazily without `afterEvaluate`
- document the local-development workflow

## Verification
- `./gradlew help -PuseMavenLocal=true --console=plain`
- `./gradlew clean check :plugin:generatePomFileForPluginMavenPublication --rerun-tasks --console=plain`
- 50 tests passed
- Gradle plugin validation and JaCoCo verification passed
- generated `pluginMaven` POM contains `<artifactId>povercat</artifactId>`