### PR TITLE
Fix coverage reporting configuration

### DIFF
--- a/.github/workflows/ci-auto-build.yml
+++ b/.github/workflows/ci-auto-build.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: the13haven/povercat-plugin
-          files: build/reports/coverage/coverage.xml
+          files: plugin/build/reports/coverage/coverage.xml
           fail_ci_if_error: true
           verbose: true
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
 jacoco {
     toolVersion = libs.jacoco.get().version!!
 
-    reportsDirectory = layout.buildDirectory.dir("reposts/coverage")
+    reportsDirectory = layout.buildDirectory.dir("reports/coverage")
 }
 
 gradlePlugin {
@@ -163,7 +163,8 @@ tasks.jacocoTestCoverageVerification {
     violationRules {
         rule {
             limit {
-                counter
+                counter = "LINE"
+                value = "COVEREDRATIO"
                 minimum = BigDecimal.valueOf(0.9)
             }
         }


### PR DESCRIPTION
## Summary
- fix the JaCoCo reports directory typo
- explicitly enforce a 90% LINE covered-ratio threshold
- point Codecov at the actual subproject XML report

## Verification
- `./gradlew clean build --rerun-tasks --console=plain`
- 50 tests passed
- Gradle plugin validation and JaCoCo verification passed
- LINE coverage: 96.00% (863/899)
- verified `plugin/build/reports/coverage/coverage.xml` exists and the old root path does not