### PR TITLE
Harden release workflows

### DIFF
--- a/.github/workflows/ci-auto-build.yml
+++ b/.github/workflows/ci-auto-build.yml
@@ -74,13 +74,13 @@ jobs:
         uses: actions/checkout@v7
 
       - name: FOSSA Scan
-        uses: fossas/fossa-action@main
+        uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           project: povercat-plugin
 
       - name: FOSSA Test
-        uses: fossas/fossa-action@main
+        uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           project: povercat-plugin

--- a/.github/workflows/ci-auto-build.yml
+++ b/.github/workflows/ci-auto-build.yml
@@ -74,13 +74,13 @@ jobs:
         uses: actions/checkout@v7
 
       - name: FOSSA Scan
-        uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
+        uses: fossas/fossa-action@v2.0.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           project: povercat-plugin
 
       - name: FOSSA Test
-        uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
+        uses: fossas/fossa-action@v2.0.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           project: povercat-plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: write
   contents: write
-  packages: write
 
 jobs:
   build:
@@ -15,11 +13,18 @@ jobs:
 
     steps:
       - name: Set up SSH Key
+        env:
+          ACTIONS_WRITE_KEY: ${{ secrets.ACTIONS_WRITE_KEY }}
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.ACTIONS_WRITE_KEY }}" > ~/.ssh/deploy_key_rsa
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$ACTIONS_WRITE_KEY" > ~/.ssh/deploy_key_rsa
           chmod 600 ~/.ssh/deploy_key_rsa
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          # Official GitHub Ed25519 host key:
+          # https://docs.github.com/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+          cat > ~/.ssh/known_hosts <<'EOF'
+          github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+          EOF
+          chmod 644 ~/.ssh/known_hosts
 
       - name: Checkout project sources
         uses: actions/checkout@v7

--- a/.github/workflows/setup-next-version.yml
+++ b/.github/workflows/setup-next-version.yml
@@ -9,9 +9,7 @@ on:
         type: string
 
 permissions:
-  actions: write
   contents: write
-  packages: write
 
 jobs:
   build:
@@ -20,11 +18,18 @@ jobs:
 
     steps:
       - name: Set up SSH Key
+        env:
+          ACTIONS_WRITE_KEY: ${{ secrets.ACTIONS_WRITE_KEY }}
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.ACTIONS_WRITE_KEY }}" > ~/.ssh/deploy_key_rsa
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$ACTIONS_WRITE_KEY" > ~/.ssh/deploy_key_rsa
           chmod 600 ~/.ssh/deploy_key_rsa
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          # Official GitHub Ed25519 host key:
+          # https://docs.github.com/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+          cat > ~/.ssh/known_hosts <<'EOF'
+          github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+          EOF
+          chmod 644 ~/.ssh/known_hosts
 
       - name: Checkout project sources
         uses: actions/checkout@v7
@@ -50,4 +55,16 @@ jobs:
           gradle-version: wrapper
 
       - name: Setup next version marker
-        run: ./gradlew markNextVersion -Prelease.version=${{ github.event.inputs.nextVersion }} -Prelease.customKeyFile="$HOME/.ssh/deploy_key_rsa" -Prelease.customKeyPassword=""
+        env:
+          NEXT_VERSION: ${{ inputs.nextVersion }}
+        run: |
+          version_pattern='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?(\+[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$'
+          if [[ ! "$NEXT_VERSION" =~ $version_pattern ]]; then
+            echo "Invalid version format"
+            exit 1
+          fi
+
+          ./gradlew markNextVersion \
+            "-Prelease.version=$NEXT_VERSION" \
+            -Prelease.customKeyFile="$HOME/.ssh/deploy_key_rsa" \
+            -Prelease.customKeyPassword=""


### PR DESCRIPTION
## Summary
- use the released `fossas/fossa-action@v2.0.0` tag in both FOSSA steps so Dependabot can maintain it consistently with the other actions
- pass `nextVersion` through the environment, validate SemVer-compatible values including `-alfa`, `-RC1`, and `-GA`, and quote the Gradle property
- replace unauthenticated `ssh-keyscan` with GitHub's published Ed25519 host key in both write workflows
- pass the SSH private key through a step environment variable instead of interpolating it into the generated shell script
- reduce setup/release workflow permissions to `contents: write`

## Verification
- parsed every workflow YAML file successfully
- verified accepted version examples: `1.2.3`, `1.2.3-alfa`, `1.2.3-RC1`, `1.2.3-GA`, `1.2.3-RC.1`, `1.2.3-RC1+build.7`
- verified shell payload examples are rejected and not executed
- verified the pinned host key fingerprint is GitHub's official Ed25519 fingerprint
- `./gradlew clean build --rerun-tasks --console=plain`
- 50 tests passed; plugin validation and JaCoCo verification passed