### PR TITLE
Refine internal Kotlin implementation

### DIFF
--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogClassGenerator.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogClassGenerator.kt
@@ -26,341 +26,336 @@ import java.time.LocalDate
  *
  * @author ssidorov@the13haven.com
  */
-class PortableVersionCatalogClassGenerator {
+internal object PortableVersionCatalogClassGenerator {
 
-    companion object {
+    private val logger = Logging.getLogger(PortableVersionCatalogClassGenerator::class.java)
 
-        private val logger = Logging.getLogger(PortableVersionCatalogClassGenerator::class.java)
+    fun generateClass(file: File, catalogPackage: String, className: String, projectVersion: String): String =
+        try {
+            val tomlContent = file.readText()
+            val toml = Toml.parse(tomlContent)
+            VersionCatalogValidator.validate(file, toml)
 
-        @JvmStatic
-        fun generateClass(file: File, catalogPackage: String, className: String, projectVersion: String): String =
-            try {
-                val tomlContent = file.readText()
-                val toml = Toml.parse(tomlContent)
-                VersionCatalogValidator.validate(file, toml)
+            val versions = toml.toMap("versions")
+            val libraries = toml.toMap("libraries")
+            val plugins = toml.toMap("plugins")
+            val bundles = toml.toMap("bundles")
 
-                val versions = toml.toMap("versions")
-                val libraries = toml.toMap("libraries")
-                val plugins = toml.toMap("plugins")
-                val bundles = toml.toMap("bundles")
+            val parsedVersions = mutableMapOf<String, TomlParserUtils.TomlVersion>()
 
-                val parsedVersions = java.util.HashMap<String, TomlParserUtils.TomlVersion>()
+            buildString {
+                appendCopyright(this)
+                appendLine()
+                appendLine("package $catalogPackage")
+                appendLine()
+                appendImports(this)
+                appendLine()
+                appendClassJavaDoc(this, projectVersion)
+                appendLine("class $className private constructor() {")
+                appendLine()
 
-                buildString {
-                    appendCopyright(this)
-                    appendLine()
-                    appendLine("package $catalogPackage")
-                    appendLine()
-                    appendImports(this)
-                    appendLine()
-                    appendClassJavaDoc(this, projectVersion)
-                    appendLine("class $className private constructor() {")
-                    appendLine()
+                generateVersionPart(this, versions, parsedVersions)
 
-                    generateVersionPart(this, versions, parsedVersions)
+                generateLibraryPart(this, libraries, parsedVersions)
 
-                    generateLibraryPart(this, libraries, parsedVersions)
+                generateBundlesPart(this, bundles)
 
-                    generateBundlesPart(this, bundles)
+                generatePluginsPart(this, plugins, parsedVersions)
 
-                    generatePluginsPart(this, plugins, parsedVersions)
-
-                    appendLine()
-                    appendGradleTypeAdapters(this)
-                    appendLine("}")
-                }
-            } catch (e: Exception) {
-                logger.error("An error occurred while generation portable version catalog {}", className, e)
-
-                throw e
+                appendLine()
+                appendGradleTypeAdapters(this)
+                appendLine("}")
             }
+        } catch (e: Exception) {
+            logger.error("An error occurred while generating portable version catalog {}", className, e)
 
-
-        private fun generateVersionPart(
-            stringBuilder: StringBuilder,
-            versions: Map<String, Any>,
-            parsedVersions: HashMap<String, TomlParserUtils.TomlVersion>
-        ) {
-            if (versions.isNotEmpty()) {
-                with(stringBuilder) {
-                    appendLine("    object Versions {")
-
-                    versions.forEach { (key, value) ->
-                        val parsedVersion = TomlParserUtils.parseVersion(value)
-
-                        if (parsedVersion.isNotEmpty()) {
-                            parsedVersions[CatalogAlias.normalize(key)] = parsedVersion
-
-                            appendLine()
-                            appendLine("        @JvmStatic")
-                            appendLine(
-                                "        val ${TomlParserUtils.toCamelCase(key)}: VersionConstraint = " +
-                                        "CatalogGradleTypeFactory.version(${parsedVersion.render()})"
-                            )
-                        }
-                    }
-
-                    appendLine("    }")
-                    appendLine()
-                }
-            }
+            throw e
         }
 
-        private fun generateLibraryPart(
-            stringBuilder: StringBuilder,
-            libraries: Map<String, Any>,
-            parsedVersions: Map<String, TomlParserUtils.TomlVersion>
-        ) {
-            if (libraries.isNotEmpty()) {
-                with(stringBuilder) {
-
-                    appendLine("    object Libraries {")
-
-                    libraries.forEach { (key, value) ->
-                        val parsedLibrary = TomlParserUtils.parseLibrary(value, parsedVersions)
-
-                        if (parsedLibrary.isNotEmpty()) {
-                            val libraryName = TomlParserUtils.toCamelCase(key)
-
-                            appendLine()
-                            appendLine("        @JvmStatic")
-                            appendLine(
-                                "        val $libraryName: MinimalExternalModuleDependency = " +
-                                        "CatalogGradleTypeFactory.library("
-                            )
-                            appendLine(
-                                "            CatalogLibrary(" +
-                                        "${KotlinSourceEscaping.stringLiteral(parsedLibrary.group)}, " +
-                                        "${KotlinSourceEscaping.stringLiteral(parsedLibrary.name)}, " +
-                                        "${parsedLibrary.version.render()}" +
-                                        ")"
-                            )
-                            appendLine("        )")
-                        }
-                    }
-
-                    appendLine("    }")
-                    appendLine()
-                }
-            }
-        }
-
-        private fun generateBundlesPart(stringBuilder: StringBuilder, bundles: Map<String, Any>) {
-            if (bundles.isNotEmpty()) {
-                with(stringBuilder) {
-                    appendLine("    object Bundles {")
-
-                    bundles.forEach { (key, value) ->
-                        val bundleLibraries = TomlParserUtils.parseBundle(value)
-
-                        if (bundleLibraries.isNotEmpty()) {
-                            val bundleName = TomlParserUtils.toCamelCase(key)
-
-                            appendLine()
-                            appendLine("        @JvmStatic")
-                            appendLine(
-                                "        fun $bundleName(objectFactory: ObjectFactory): " +
-                                        "Provider<ExternalModuleDependencyBundle> ="
-                            )
-                            appendLine(
-                                "            objectFactory.property(" +
-                                        "ExternalModuleDependencyBundle::class.java" +
-                                        ").apply {"
-                            )
-                            appendLine("                set(")
-                            appendLine("                    CatalogGradleTypeFactory.bundle(")
-                            appendLine("                        listOf(")
-                            appendLine(
-                                bundleLibraries.joinToString(",\n") {
-                                    "                            Libraries.$it"
-                                }
-                            )
-                            appendLine("                        )")
-                            appendLine("                    )")
-                            appendLine("                )")
-                            appendLine("            }")
-                        }
-                    }
-
-                    appendLine("    }")
-                    appendLine()
-                }
-            }
-        }
-
-        private fun generatePluginsPart(
-            stringBuilder: StringBuilder,
-            plugins: Map<String, Any>,
-            parsedVersions: Map<String, TomlParserUtils.TomlVersion>
-        ) {
-            if (plugins.isNotEmpty()) {
-                with(stringBuilder) {
-                    appendLine("    object Plugins {")
-
-                    plugins.forEach { (key, value) ->
-                        val plugin = TomlParserUtils.parsePlugin(value, parsedVersions)
-
-                        if (plugin.isNotEmpty()) {
-                            appendLine()
-                            appendLine("        @JvmStatic")
-                            appendLine(
-                                "        val ${TomlParserUtils.toCamelCase(key)}: PluginDependency = " +
-                                        "CatalogGradleTypeFactory.plugin(" +
-                                        "${KotlinSourceEscaping.stringLiteral(plugin.id)}, " +
-                                        "${plugin.version.render()}" +
-                                        ")"
-                            )
-                        }
-                    }
-
-                    appendLine("    }")
-                }
-            }
-        }
-
-        private fun appendGradleTypeAdapters(stringBuilder: StringBuilder) {
+    private fun generateVersionPart(
+        stringBuilder: StringBuilder,
+        versions: Map<String, Any>,
+        parsedVersions: MutableMap<String, TomlParserUtils.TomlVersion>
+    ) {
+        if (versions.isNotEmpty()) {
             with(stringBuilder) {
-                appendLine("    private data class CatalogVersion(")
-                appendLine("        val requiredVersion: String,")
-                appendLine("        val strictVersion: String,")
-                appendLine("        val preferredVersion: String,")
-                appendLine("        val rejectedVersions: List<String>")
-                appendLine("    )")
+                appendLine("    object Versions {")
+
+                versions.forEach { (key, value) ->
+                    val parsedVersion = TomlParserUtils.parseVersion(value)
+
+                    if (parsedVersion.isNotEmpty()) {
+                        parsedVersions[CatalogAlias.normalize(key)] = parsedVersion
+
+                        appendLine()
+                        appendLine("        @JvmStatic")
+                        appendLine(
+                            "        val ${TomlParserUtils.toCamelCase(key)}: VersionConstraint = " +
+                                    "CatalogGradleTypeFactory.version(${parsedVersion.render()})"
+                        )
+                    }
+                }
+
+                appendLine("    }")
                 appendLine()
-                appendLine("    private data class CatalogLibrary(")
-                appendLine("        val group: String,")
-                appendLine("        val name: String,")
-                appendLine("        val version: CatalogVersion")
-                appendLine("    )")
+            }
+        }
+    }
+
+    private fun generateLibraryPart(
+        stringBuilder: StringBuilder,
+        libraries: Map<String, Any>,
+        parsedVersions: Map<String, TomlParserUtils.TomlVersion>
+    ) {
+        if (libraries.isNotEmpty()) {
+            with(stringBuilder) {
+
+                appendLine("    object Libraries {")
+
+                libraries.forEach { (key, value) ->
+                    val parsedLibrary = TomlParserUtils.parseLibrary(value, parsedVersions)
+
+                    if (parsedLibrary.isNotEmpty()) {
+                        val libraryName = TomlParserUtils.toCamelCase(key)
+
+                        appendLine()
+                        appendLine("        @JvmStatic")
+                        appendLine(
+                            "        val $libraryName: MinimalExternalModuleDependency = " +
+                                    "CatalogGradleTypeFactory.library("
+                        )
+                        appendLine(
+                            "            CatalogLibrary(" +
+                                    "${KotlinSourceEscaping.stringLiteral(parsedLibrary.group)}, " +
+                                    "${KotlinSourceEscaping.stringLiteral(parsedLibrary.name)}, " +
+                                    "${parsedLibrary.version.render()}" +
+                                    ")"
+                        )
+                        appendLine("        )")
+                    }
+                }
+
+                appendLine("    }")
                 appendLine()
-                appendLine("    private object CatalogGradleTypeFactory {")
-                appendLine("        fun version(version: CatalogVersion): VersionConstraint =")
-                appendLine("            mutableVersion(version).asImmutable()")
+            }
+        }
+    }
+
+    private fun generateBundlesPart(stringBuilder: StringBuilder, bundles: Map<String, Any>) {
+        if (bundles.isNotEmpty()) {
+            with(stringBuilder) {
+                appendLine("    object Bundles {")
+
+                bundles.forEach { (key, value) ->
+                    val bundleLibraries = TomlParserUtils.parseBundle(value)
+
+                    if (bundleLibraries.isNotEmpty()) {
+                        val bundleName = TomlParserUtils.toCamelCase(key)
+
+                        appendLine()
+                        appendLine("        @JvmStatic")
+                        appendLine(
+                            "        fun $bundleName(objectFactory: ObjectFactory): " +
+                                    "Provider<ExternalModuleDependencyBundle> ="
+                        )
+                        appendLine(
+                            "            objectFactory.property(" +
+                                    "ExternalModuleDependencyBundle::class.java" +
+                                    ").apply {"
+                        )
+                        appendLine("                set(")
+                        appendLine("                    CatalogGradleTypeFactory.bundle(")
+                        appendLine("                        listOf(")
+                        appendLine(
+                            bundleLibraries.joinToString(",\n") {
+                                "                            Libraries.$it"
+                            }
+                        )
+                        appendLine("                        )")
+                        appendLine("                    )")
+                        appendLine("                )")
+                        appendLine("            }")
+                    }
+                }
+
+                appendLine("    }")
                 appendLine()
-                appendLine(
-                    "        fun library(library: CatalogLibrary): " +
-                            "MinimalExternalModuleDependency ="
-                )
-                appendLine("            DefaultMinimalDependency(")
-                appendLine("                DefaultModuleIdentifier.newId(library.group, library.name),")
-                appendLine("                mutableVersion(library.version)")
-                appendLine("            )")
-                appendLine()
-                appendLine(
-                    "        fun bundle(dependencies: List<MinimalExternalModuleDependency>): " +
-                            "ExternalModuleDependencyBundle ="
-                )
-                appendLine("            DefaultExternalModuleDependencyBundle().apply {")
-                appendLine("                addAll(dependencies)")
-                appendLine("            }")
-                appendLine()
-                appendLine(
-                    "        fun plugin(id: String, version: CatalogVersion): PluginDependency ="
-                )
-                appendLine("            DefaultPluginDependency(id, mutableVersion(version))")
-                appendLine()
-                appendLine(
-                    "        private fun mutableVersion(version: CatalogVersion): " +
-                            "DefaultMutableVersionConstraint ="
-                )
-                appendLine("            DefaultMutableVersionConstraint(\"\").apply {")
-                appendLine("                if (version.requiredVersion.isNotBlank()) {")
-                appendLine("                    require(version.requiredVersion)")
-                appendLine("                }")
-                appendLine("                if (version.strictVersion.isNotBlank()) {")
-                appendLine("                    strictly(version.strictVersion)")
-                appendLine("                }")
-                appendLine("                if (version.preferredVersion.isNotBlank()) {")
-                appendLine("                    prefer(version.preferredVersion)")
-                appendLine("                }")
-                appendLine("                when {")
-                appendLine("                    version.rejectedVersions == listOf(\"+\") -> rejectAll()")
-                appendLine(
-                    "                    version.rejectedVersions.isNotEmpty() -> " +
-                            "reject(*version.rejectedVersions.toTypedArray())"
-                )
-                appendLine("                }")
-                appendLine("            }")
+            }
+        }
+    }
+
+    private fun generatePluginsPart(
+        stringBuilder: StringBuilder,
+        plugins: Map<String, Any>,
+        parsedVersions: Map<String, TomlParserUtils.TomlVersion>
+    ) {
+        if (plugins.isNotEmpty()) {
+            with(stringBuilder) {
+                appendLine("    object Plugins {")
+
+                plugins.forEach { (key, value) ->
+                    val plugin = TomlParserUtils.parsePlugin(value, parsedVersions)
+
+                    if (plugin.isNotEmpty()) {
+                        appendLine()
+                        appendLine("        @JvmStatic")
+                        appendLine(
+                            "        val ${TomlParserUtils.toCamelCase(key)}: PluginDependency = " +
+                                    "CatalogGradleTypeFactory.plugin(" +
+                                    "${KotlinSourceEscaping.stringLiteral(plugin.id)}, " +
+                                    "${plugin.version.render()}" +
+                                    ")"
+                        )
+                    }
+                }
+
                 appendLine("    }")
             }
         }
+    }
 
-        private fun TomlParserUtils.TomlVersion.render(): String =
-            "CatalogVersion(" +
-                    "requiredVersion = ${KotlinSourceEscaping.stringLiteral(requiredVersion)}, " +
-                    "strictVersion = ${KotlinSourceEscaping.stringLiteral(strictVersion)}, " +
-                    "preferredVersion = ${KotlinSourceEscaping.stringLiteral(preferredVersion)}, " +
-                    "rejectedVersions = ${rejectedVersions.renderStringList()}" +
-                    ")"
+    private fun appendGradleTypeAdapters(stringBuilder: StringBuilder) {
+        with(stringBuilder) {
+            appendLine("    private data class CatalogVersion(")
+            appendLine("        val requiredVersion: String,")
+            appendLine("        val strictVersion: String,")
+            appendLine("        val preferredVersion: String,")
+            appendLine("        val rejectedVersions: List<String>")
+            appendLine("    )")
+            appendLine()
+            appendLine("    private data class CatalogLibrary(")
+            appendLine("        val group: String,")
+            appendLine("        val name: String,")
+            appendLine("        val version: CatalogVersion")
+            appendLine("    )")
+            appendLine()
+            appendLine("    private object CatalogGradleTypeFactory {")
+            appendLine("        fun version(version: CatalogVersion): VersionConstraint =")
+            appendLine("            mutableVersion(version).asImmutable()")
+            appendLine()
+            appendLine(
+                "        fun library(library: CatalogLibrary): " +
+                        "MinimalExternalModuleDependency ="
+            )
+            appendLine("            DefaultMinimalDependency(")
+            appendLine("                DefaultModuleIdentifier.newId(library.group, library.name),")
+            appendLine("                mutableVersion(library.version)")
+            appendLine("            )")
+            appendLine()
+            appendLine(
+                "        fun bundle(dependencies: List<MinimalExternalModuleDependency>): " +
+                        "ExternalModuleDependencyBundle ="
+            )
+            appendLine("            DefaultExternalModuleDependencyBundle().apply {")
+            appendLine("                addAll(dependencies)")
+            appendLine("            }")
+            appendLine()
+            appendLine(
+                "        fun plugin(id: String, version: CatalogVersion): PluginDependency ="
+            )
+            appendLine("            DefaultPluginDependency(id, mutableVersion(version))")
+            appendLine()
+            appendLine(
+                "        private fun mutableVersion(version: CatalogVersion): " +
+                        "DefaultMutableVersionConstraint ="
+            )
+            appendLine("            DefaultMutableVersionConstraint(\"\").apply {")
+            appendLine("                if (version.requiredVersion.isNotBlank()) {")
+            appendLine("                    require(version.requiredVersion)")
+            appendLine("                }")
+            appendLine("                if (version.strictVersion.isNotBlank()) {")
+            appendLine("                    strictly(version.strictVersion)")
+            appendLine("                }")
+            appendLine("                if (version.preferredVersion.isNotBlank()) {")
+            appendLine("                    prefer(version.preferredVersion)")
+            appendLine("                }")
+            appendLine("                when {")
+            appendLine("                    version.rejectedVersions == listOf(\"+\") -> rejectAll()")
+            appendLine(
+                "                    version.rejectedVersions.isNotEmpty() -> " +
+                        "reject(*version.rejectedVersions.toTypedArray())"
+            )
+            appendLine("                }")
+            appendLine("            }")
+            appendLine("    }")
+        }
+    }
 
-        private fun List<String>.renderStringList(): String =
-            if (isEmpty()) {
-                "emptyList()"
-            } else {
-                joinToString(prefix = "listOf(", postfix = ")") {
-                    KotlinSourceEscaping.stringLiteral(it)
-                }
-            }
+    private fun TomlParserUtils.TomlVersion.render(): String =
+        "CatalogVersion(" +
+                "requiredVersion = ${KotlinSourceEscaping.stringLiteral(requiredVersion)}, " +
+                "strictVersion = ${KotlinSourceEscaping.stringLiteral(strictVersion)}, " +
+                "preferredVersion = ${KotlinSourceEscaping.stringLiteral(preferredVersion)}, " +
+                "rejectedVersions = ${rejectedVersions.renderStringList()}" +
+                ")"
 
-        private fun appendCopyright(stringBuilder: StringBuilder) {
-            with(stringBuilder) {
-                appendLine("/*")
-                appendLine(" * Copyright ${LocalDate.now().year}")
-                appendLine(" *")
-                appendLine(" * Licensed under the Apache License, Version 2.0 (the \"License\");")
-                appendLine(" * you may not use this file except in compliance with the License.")
-                appendLine(" * You may obtain a copy of the License at")
-                appendLine(" *")
-                appendLine(" * http://www.apache.org/licenses/LICENSE-2.0")
-                appendLine(" *")
-                appendLine(" * Unless required by applicable law or agreed to in writing, software distributed")
-                appendLine(" * under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES")
-                appendLine(" * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the")
-                appendLine(" * specific language governing permissions and limitations under the License.")
-                appendLine(" */")
+    private fun List<String>.renderStringList(): String =
+        if (isEmpty()) {
+            "emptyList()"
+        } else {
+            joinToString(prefix = "listOf(", postfix = ")") {
+                KotlinSourceEscaping.stringLiteral(it)
             }
         }
 
-        private fun appendImports(stringBuilder: StringBuilder) {
-            with(stringBuilder) {
-                appendLine("import org.gradle.api.artifacts.ExternalModuleDependencyBundle")
-                appendLine("import org.gradle.api.artifacts.MinimalExternalModuleDependency")
-                appendLine("import org.gradle.api.artifacts.VersionConstraint")
-                appendLine("import org.gradle.api.internal.artifacts.DefaultModuleIdentifier")
-                appendLine("import org.gradle.api.internal.artifacts.dependencies.DefaultMinimalDependency")
-                appendLine("import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint")
-                appendLine("import org.gradle.api.internal.artifacts.dependencies.DefaultPluginDependency")
-                appendLine("import org.gradle.api.internal.catalog.DefaultExternalModuleDependencyBundle")
-                appendLine("import org.gradle.api.model.ObjectFactory")
-                appendLine("import org.gradle.api.provider.Provider")
-                appendLine("import org.gradle.plugin.use.PluginDependency")
-            }
+    private fun appendCopyright(stringBuilder: StringBuilder) {
+        with(stringBuilder) {
+            appendLine("/*")
+            appendLine(" * Copyright ${LocalDate.now().year}")
+            appendLine(" *")
+            appendLine(" * Licensed under the Apache License, Version 2.0 (the \"License\");")
+            appendLine(" * you may not use this file except in compliance with the License.")
+            appendLine(" * You may obtain a copy of the License at")
+            appendLine(" *")
+            appendLine(" * http://www.apache.org/licenses/LICENSE-2.0")
+            appendLine(" *")
+            appendLine(" * Unless required by applicable law or agreed to in writing, software distributed")
+            appendLine(" * under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES")
+            appendLine(" * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the")
+            appendLine(" * specific language governing permissions and limitations under the License.")
+            appendLine(" */")
         }
+    }
 
-        private fun appendClassJavaDoc(stringBuilder: StringBuilder, projectVersion: String) {
-            with(stringBuilder) {
-                appendLine("/**")
-                appendLine(" * <p><strong>WARNING: This class is auto-generated by PoVerCat plugin. Do not modify it manually.</strong></p>")
-                appendLine(" *")
-                appendLine(" * This class provides access to the version catalog of the Gradle project,")
-                appendLine(" * which defines conventions for other projects. All dependencies and versions")
-                appendLine(" * are statically embedded in this class and are immutable.")
-                appendLine(" *")
-                appendLine(" * <p>To update versions, modify them in the version catalog of the convention")
-                appendLine(" * project and rebuild it.</p>")
-                appendLine(" *")
-                appendLine(" * @author PoVerCat plugin")
-                appendLine(
-                    " * @version v${KotlinSourceEscaping.kDocText(projectVersion)}"
-                )
-                appendLine(" */")
-            }
+    private fun appendImports(stringBuilder: StringBuilder) {
+        with(stringBuilder) {
+            appendLine("import org.gradle.api.artifacts.ExternalModuleDependencyBundle")
+            appendLine("import org.gradle.api.artifacts.MinimalExternalModuleDependency")
+            appendLine("import org.gradle.api.artifacts.VersionConstraint")
+            appendLine("import org.gradle.api.internal.artifacts.DefaultModuleIdentifier")
+            appendLine("import org.gradle.api.internal.artifacts.dependencies.DefaultMinimalDependency")
+            appendLine("import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint")
+            appendLine("import org.gradle.api.internal.artifacts.dependencies.DefaultPluginDependency")
+            appendLine("import org.gradle.api.internal.catalog.DefaultExternalModuleDependencyBundle")
+            appendLine("import org.gradle.api.model.ObjectFactory")
+            appendLine("import org.gradle.api.provider.Provider")
+            appendLine("import org.gradle.plugin.use.PluginDependency")
         }
+    }
 
-        private fun TomlParseResult.toMap(key: String): Map<String, Any> {
-            // Catalog entry order has no semantic meaning, so generation deliberately uses the
-            // parser-provided iteration order instead of imposing an unrelated canonical sort.
-            return getTable(key)?.toMap() ?: emptyMap()
+    private fun appendClassJavaDoc(stringBuilder: StringBuilder, projectVersion: String) {
+        with(stringBuilder) {
+            appendLine("/**")
+            appendLine(" * <p><strong>WARNING: This class is auto-generated by PoVerCat plugin. Do not modify it manually.</strong></p>")
+            appendLine(" *")
+            appendLine(" * This class provides access to the version catalog of the Gradle project,")
+            appendLine(" * which defines conventions for other projects. All dependencies and versions")
+            appendLine(" * are statically embedded in this class and are immutable.")
+            appendLine(" *")
+            appendLine(" * <p>To update versions, modify them in the version catalog of the convention")
+            appendLine(" * project and rebuild it.</p>")
+            appendLine(" *")
+            appendLine(" * @author PoVerCat plugin")
+            appendLine(
+                " * @version v${KotlinSourceEscaping.kDocText(projectVersion)}"
+            )
+            appendLine(" */")
         }
+    }
+
+    private fun TomlParseResult.toMap(key: String): Map<String, Any> {
+        // Catalog entry order has no semantic meaning, so generation deliberately uses the
+        // parser-provided iteration order instead of imposing an unrelated canonical sort.
+        return getTable(key)?.toMap() ?: emptyMap()
     }
 }

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginExtension.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginExtension.kt
@@ -48,7 +48,7 @@ open class PortableVersionCatalogGeneratorPluginExtension(project: Project) {
         .convention(project.layout.buildDirectory.dir("generated/sources/povercat"))
 
     companion object {
-        fun Project.portableVersionCatalog(): PortableVersionCatalogGeneratorPluginExtension =
+        internal fun Project.portableVersionCatalog(): PortableVersionCatalogGeneratorPluginExtension =
             extensions.create(
                 "portableVersionCatalog",
                 PortableVersionCatalogGeneratorPluginExtension::class.java,

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTask.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/PortableVersionCatalogGeneratorPluginTask.kt
@@ -413,7 +413,9 @@ abstract class PortableVersionCatalogGeneratorPluginTask : DefaultTask() {
             "while"
         )
 
-        fun Project.generatePortableVersionCatalogTask(extension: PortableVersionCatalogGeneratorPluginExtension): TaskProvider<PortableVersionCatalogGeneratorPluginTask> {
+        internal fun Project.generatePortableVersionCatalogTask(
+            extension: PortableVersionCatalogGeneratorPluginExtension
+        ): TaskProvider<PortableVersionCatalogGeneratorPluginTask> {
             val projectVersionProvider = provider { version.toString() }
 
             return tasks.register<PortableVersionCatalogGeneratorPluginTask>("generatePortableVersionCatalog") {

--- a/plugin/src/main/kotlin/com/the13haven/gradle/povercat/TomlParserUtils.kt
+++ b/plugin/src/main/kotlin/com/the13haven/gradle/povercat/TomlParserUtils.kt
@@ -24,145 +24,131 @@ import org.tomlj.TomlTable
  *
  * @author ssidorov@the13haven.com
  */
-class TomlParserUtils {
+internal object TomlParserUtils {
+    private const val EMPTY_STRING = ""
 
-    companion object {
-        private const val EMPTY_STRING = ""
+    private const val VERSION_KEY = "version"
+    private const val REF_KEY = "ref"
+    private const val REJECT_ALL_KEY = "rejectAll"
+    private const val REQUIRE_KEY = "require"
+    private const val STRICTLY_KEY = "strictly"
+    private const val PREFER_KEY = "prefer"
+    private const val REJECT_KEY = "reject"
+    private const val MODULE_KEY = "module"
+    private const val GROUP_KEY = "group"
+    private const val NAME_KEY = "name"
+    private const val ID_KEY = "id"
 
-        private const val VERSION_KEY = "version"
-        private const val REF_KEY = "ref"
-        private const val REJECT_ALL_KEY = "rejectAll"
-        private const val REQUIRE_KEY = "require"
-        private const val STRICTLY_KEY = "strictly"
-        private const val PREFER_KEY = "prefer"
-        private const val REJECT_KEY = "reject"
-        private const val MODULE_KEY = "module"
-        private const val GROUP_KEY = "group"
-        private const val NAME_KEY = "name"
-        private const val ID_KEY = "id"
+    private val EMPTY_VERSION = TomlVersion()
 
-        @JvmStatic
-        val EMPTY_VERSION = TomlVersion()
+    private val EMPTY_PLUGIN = TomlPlugin()
 
-        @JvmStatic
-        val EMPTY_PLUGIN = TomlPlugin()
+    private val REJECT_ALL_VERSION = TomlVersion(EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, listOf("+"))
 
-        @JvmStatic
-        val REJECT_ALL_VERSION = TomlVersion(EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, listOf("+"))
+    fun toCamelCase(value: String): String =
+        CatalogAlias.toAccessorName(value)
 
-        @JvmStatic
-        fun toCamelCase(value: String): String =
-            CatalogAlias.toAccessorName(value)
-
-        @JvmStatic
-        fun parseVersion(versionValue: Any): TomlVersion {
-            if (versionValue is TomlTable) {
-                val rejectAll = versionValue.getBoolean(REJECT_ALL_KEY) { false }
-
-                if (rejectAll) {
-                    return REJECT_ALL_VERSION
-                }
-
-                val require = versionValue.getString(REQUIRE_KEY) { EMPTY_STRING }
-                val strictly = versionValue.getString(STRICTLY_KEY) { EMPTY_STRING }
-                val prefer = versionValue.getString(PREFER_KEY) { EMPTY_STRING }
-                val reject = versionValue.getArrayOrEmpty(REJECT_KEY)
-                    .toList()
-                    .map { it.toString() }
-                    .toList()
-
-                return TomlVersion(
-                    require,
-                    strictly,
-                    prefer,
-                    reject
-                )
-            } else {
-                return TomlVersion(versionValue.toString())
-            }
+    fun parseVersion(versionValue: Any): TomlVersion {
+        if (versionValue !is TomlTable) {
+            return TomlVersion(versionValue.toString())
         }
 
-        @JvmStatic
-        fun parseLibrary(libraryValue: Any, versions: Map<String, TomlVersion>): TomlLibrary {
-            if (libraryValue is TomlTable) {
-                val version = parseInlineVersion(libraryValue.get(VERSION_KEY), versions)
-                val module = libraryValue.getString(MODULE_KEY) { EMPTY_STRING }
+        val rejectAll = versionValue.getBoolean(REJECT_ALL_KEY) { false }
 
-                if (module.isBlank()) {
-                    val group = libraryValue.getString(GROUP_KEY) { EMPTY_STRING }
-                    val name = libraryValue.getString(NAME_KEY) { EMPTY_STRING }
-
-                    return TomlLibrary(group, name, version)
-                } else {
-                    return parseLibrarySimple(module, version)
-                }
-
-            } else {
-                return parseLibrarySimple(libraryValue.toString())
-            }
+        if (rejectAll) {
+            return REJECT_ALL_VERSION
         }
 
-        @JvmStatic
-        fun parseBundle(bundleValue: Any): List<String> {
-            return if (bundleValue is TomlArray) {
-                bundleValue.toList()
-                    .map { it.toString() }
-                    .map { toCamelCase(it) }
-            } else {
-                emptyList()
-            }
+        val require = versionValue.getString(REQUIRE_KEY) { EMPTY_STRING }
+        val strictly = versionValue.getString(STRICTLY_KEY) { EMPTY_STRING }
+        val prefer = versionValue.getString(PREFER_KEY) { EMPTY_STRING }
+        val reject = versionValue.getArrayOrEmpty(REJECT_KEY)
+            .toList()
+            .map { it.toString() }
+
+        return TomlVersion(
+            require,
+            strictly,
+            prefer,
+            reject
+        )
+    }
+
+    fun parseLibrary(libraryValue: Any, versions: Map<String, TomlVersion>): TomlLibrary {
+        if (libraryValue !is TomlTable) {
+            return parseLibrarySimple(libraryValue.toString())
         }
 
-        @JvmStatic
-        fun parsePlugin(pluginValue: Any, versions: Map<String, TomlVersion>): TomlPlugin {
-            return if (pluginValue is TomlTable) {
-                val id = pluginValue.getString(ID_KEY) { EMPTY_STRING }
-                val version = parseInlineVersion(pluginValue.get(VERSION_KEY), versions)
+        val version = parseInlineVersion(libraryValue.get(VERSION_KEY), versions)
+        val module = libraryValue.getString(MODULE_KEY) { EMPTY_STRING }
 
-                TomlPlugin(id, version)
-            } else {
-                EMPTY_PLUGIN
-            }
+        return if (module.isBlank()) {
+            val group = libraryValue.getString(GROUP_KEY) { EMPTY_STRING }
+            val name = libraryValue.getString(NAME_KEY) { EMPTY_STRING }
+
+            TomlLibrary(group, name, version)
+        } else {
+            parseLibrarySimple(module, version)
+        }
+    }
+
+    fun parseBundle(bundleValue: Any): List<String> =
+        if (bundleValue is TomlArray) {
+            bundleValue.toList()
+                .map { toCamelCase(it.toString()) }
+        } else {
+            emptyList()
         }
 
-        private fun parseInlineVersion(versionPart: Any?, versions: Map<String, TomlVersion>): TomlVersion {
-            return if (versionPart == null) {
+    fun parsePlugin(pluginValue: Any, versions: Map<String, TomlVersion>): TomlPlugin =
+        if (pluginValue is TomlTable) {
+            val id = pluginValue.getString(ID_KEY) { EMPTY_STRING }
+            val version = parseInlineVersion(pluginValue.get(VERSION_KEY), versions)
+
+            TomlPlugin(id, version)
+        } else {
+            EMPTY_PLUGIN
+        }
+
+    private fun parseInlineVersion(versionPart: Any?, versions: Map<String, TomlVersion>): TomlVersion =
+        when (versionPart) {
+            null -> {
                 // case 1: no version
                 EMPTY_VERSION
-            } else {
-                if (versionPart is TomlTable) {
-                    val refVersionKey = versionPart.getString(REF_KEY) { EMPTY_STRING }
+            }
 
-                    if (refVersionKey.isBlank()) {
-                        // case 2: version as object
-                        parseVersion(versionPart)
-                    } else {
-                        // case 3: ref to version
-                        versions.getOrDefault(
-                            CatalogAlias.normalize(refVersionKey),
-                            EMPTY_VERSION
-                        )
-                    }
+            is TomlTable -> {
+                val refVersionKey = versionPart.getString(REF_KEY) { EMPTY_STRING }
+
+                if (refVersionKey.isBlank()) {
+                    // case 2: version as object
+                    parseVersion(versionPart)
                 } else {
-                    // case 4: simple version
-                    TomlVersion(versionPart.toString())
+                    // case 3: ref to version
+                    versions.getOrDefault(
+                        CatalogAlias.normalize(refVersionKey),
+                        EMPTY_VERSION
+                    )
                 }
+            }
+
+            else -> {
+                // case 4: simple version
+                TomlVersion(versionPart.toString())
             }
         }
 
-        private fun parseLibrarySimple(libraryExpression: String, defaultVersion: TomlVersion? = null): TomlLibrary {
-            val libraryParts = libraryExpression.split(":")
-                .toList()
+    private fun parseLibrarySimple(libraryExpression: String, defaultVersion: TomlVersion? = null): TomlLibrary {
+        val libraryParts = libraryExpression.split(":")
 
-            val version = defaultVersion
-                ?: if (libraryParts.size == 3) {
-                    TomlVersion(libraryParts[2])
-                } else {
-                    EMPTY_VERSION
-                }
+        val version = defaultVersion
+            ?: if (libraryParts.size == 3) {
+                TomlVersion(libraryParts[2])
+            } else {
+                EMPTY_VERSION
+            }
 
-            return TomlLibrary(libraryParts[0], libraryParts[1], version)
-        }
+        return TomlLibrary(libraryParts[0], libraryParts[1], version)
     }
 
     data class TomlVersion(
@@ -177,9 +163,9 @@ class TomlParserUtils {
 
         fun isEmpty(): Boolean =
             requiredVersion.isBlank()
-                    && strictVersion.isBlank()
-                    && preferredVersion.isBlank()
-                    && rejectedVersions.isEmpty()
+                && strictVersion.isBlank()
+                && preferredVersion.isBlank()
+                && rejectedVersions.isEmpty()
 
         fun isNotEmpty(): Boolean = !isEmpty()
     }


### PR DESCRIPTION
## Summary
- replace stateless utility classes and companion objects with internal Kotlin objects
- keep project/task registration helpers internal and narrow implementation-only constants
- use idiomatic Kotlin collections and simplify parser control flow without changing behavior

## Validation
- `./gradlew clean build --rerun-tasks --console=plain`
- 50 tests passed; 0 failures, 0 errors, 0 skipped
- JaCoCo coverage verification and Gradle plugin validation passed