### PR TITLE
Restore release workflow write permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
+  packages: write
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- restore `actions: write` for the release workflow
- restore `packages: write` for release publishing

## Verification
- parsed `.github/workflows/release.yml` as YAML
- `git diff --check`